### PR TITLE
Co-op geoscape: ally activity indicator + two-way time freeze

### DIFF
--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -1759,7 +1759,7 @@ void connectionTCP::initProfile(bool clientInBattle, bool inBattle)
 				connectionTCP::LobbyFileStatus = 1;
 			}
 		}
-		// CHECK IF THE HOST IS IN BATTLE — IF SO, ADD JOINERS; OTHERWISE DO NOTHING
+		// CHECK IF THE HOST IS IN BATTLE ï¿½ IF SO, ADD JOINERS; OTHERWISE DO NOTHING
 		else if (inBattle == true)
 		{
 
@@ -2355,7 +2355,26 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		std::string time_speed = obj["time_speed"].asString();
 		other_time_speed_coop = time_speed;
-	
+		// Persistent copy for the geoscape ally-speed indicator (other_time_speed_coop
+		// is cleared every timeAdvance, so it can't drive the UI on its own).
+		peerTimeSpeedId = time_speed;
+		// A "time" packet is only emitted from the geoscape, so its arrival means the
+		// peer is on the geoscape: the ally marker tracks their speed, not a sub-screen.
+		peerFocusScreen = -1;
+		// Host heartbeat: this "time" packet came from the client, so record when we
+		// last heard from them on the geoscape. The host's timeAdvance() freezes the
+		// shared clock if this goes stale (client left for base/options/etc.).
+		if (getServerOwner() == true)
+			lastClientTimePacketMs = SDL_GetTicks();
+
+	}
+
+	if (stateString == "geo_focus")
+	{
+		// coop: the peer navigated to a geoscape sub-screen (0..5 toolbar index). The
+		// ally marker on our geoscape moves to that toolbar button; -1 (back on the
+		// geoscape) is restored by the next "time" packet.
+		peerFocusScreen = obj["screen"].asInt();
 	}
 
 	if (stateString == "changeHost")
@@ -7850,6 +7869,10 @@ void connectionTCP::disconnectTCP(bool isMain)
 		_waitBC = false;
 		_waitBH = false;
 		coopSession = false;
+		// coop: clear the cached teammate geoscape speed/focus so a stale '+' marker
+		// doesn't linger after disconnect.
+		peerTimeSpeedId = "";
+		peerFocusScreen = -1;
 		connectionTCP::lobby_timer = -1;
 		connectionTCP::isCoopSessionLocked = false;
 		connectionTCP::isPlayerReady = false;

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -2358,14 +2358,15 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		// Persistent copy for the geoscape ally-speed indicator (other_time_speed_coop
 		// is cleared every timeAdvance, so it can't drive the UI on its own).
 		peerTimeSpeedId = time_speed;
-		// A "time" packet is only emitted from the geoscape, so its arrival means the
-		// peer is on the geoscape: the ally marker tracks their speed, not a sub-screen.
-		peerFocusScreen = -1;
-		// Host heartbeat: this "time" packet came from the client, so record when we
-		// last heard from them on the geoscape. The host's timeAdvance() freezes the
-		// shared clock if this goes stale (client left for base/options/etc.).
-		if (getServerOwner() == true)
-			lastClientTimePacketMs = SDL_GetTicks();
+		// A "time" packet is emitted every geoscape think() and carries where on the
+		// geoscape the sender is: -1 = normal (ally marker tracks their speed), 0 = an
+		// open dogfight window (marker -> Intercept). Navigating to a sub-screen stops
+		// these packets, so the last dedicated geo_focus value sticks instead.
+		peerFocusScreen = obj.get("geo_focus", -1).asInt();
+		// Peer heartbeat (both sides): note when we last heard from the peer on the
+		// geoscape. The host's timeAdvance() freezes the shared clock when this goes
+		// stale, and both sides dim the ally marker to yellow when it does.
+		lastPeerTimePacketMs = SDL_GetTicks();
 
 	}
 

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -359,6 +359,21 @@ class connectionTCP
 	bool pve2_init = false;
 
 	std::string other_time_speed_coop = "";
+	// coop: teammate's last-reported geoscape time-speed id ("_btn5Secs".."_btn1Day"),
+	// "" if unknown. Unlike other_time_speed_coop (consumed/cleared every timeAdvance),
+	// this persists so the geoscape UI can show which speed the ally has selected.
+	std::string peerTimeSpeedId = "";
+	// coop (host only): wall-clock ms of the last "time" heartbeat received from the
+	// client. The client emits a "time" packet every GeoscapeState::think() it spends
+	// on the geoscape; if the host hasn't seen one recently the client is away
+	// (base/options/etc.) and the host freezes the shared clock. Written on the
+	// packet-handler thread, read on the main thread, hence atomic.
+	std::atomic<Uint32> lastClientTimePacketMs{0};
+	// coop: which geoscape location the teammate is looking at, for the ally marker.
+	// -1 = on the geoscape (use peerTimeSpeedId); 0..5 = a toolbar sub-screen index
+	// (Intercept/Bases/Graphs/Ufopaedia/Options/Funding). Reset to -1 whenever a
+	// "time" packet arrives (those are only sent from the geoscape).
+	std::atomic<int> peerFocusScreen{-1};
 
 	int show_coop_mission_popup = -1;
 

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -363,12 +363,13 @@ class connectionTCP
 	// "" if unknown. Unlike other_time_speed_coop (consumed/cleared every timeAdvance),
 	// this persists so the geoscape UI can show which speed the ally has selected.
 	std::string peerTimeSpeedId = "";
-	// coop (host only): wall-clock ms of the last "time" heartbeat received from the
-	// client. The client emits a "time" packet every GeoscapeState::think() it spends
-	// on the geoscape; if the host hasn't seen one recently the client is away
-	// (base/options/etc.) and the host freezes the shared clock. Written on the
-	// packet-handler thread, read on the main thread, hence atomic.
-	std::atomic<Uint32> lastClientTimePacketMs{0};
+	// coop: wall-clock ms of the last "time" heartbeat received from the peer,
+	// updated on both sides. A "time" packet is emitted every GeoscapeState::think()
+	// the peer spends on the geoscape; if it goes stale the peer is away
+	// (base/options/popup/etc.). The host uses this to freeze the shared clock, and
+	// both sides use it to dim the ally marker to yellow. Written on the packet-handler
+	// thread, read on the main thread, hence atomic.
+	std::atomic<Uint32> lastPeerTimePacketMs{0};
 	// coop: which geoscape location the teammate is looking at, for the ally marker.
 	// -1 = on the geoscape (use peerTimeSpeedId); 0..5 = a toolbar sub-screen index
 	// (Intercept/Bases/Graphs/Ufopaedia/Options/Funding). Reset to -1 whenever a

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -37,6 +37,7 @@
 #include "Globe.h"
 #include "../Interface/ComboBox.h"
 #include "../Interface/Text.h"
+#include "../Engine/Palette.h"
 #include "../Interface/TextButton.h"
 #include "../Engine/Timer.h"
 #include "../Savegame/GameTime.h"
@@ -363,6 +364,34 @@ GeoscapeState::GeoscapeState() : _pause(false), _zoomInEffectDone(false), _zoomO
 	_btn1Day->setGroup(&_timeSpeed);
 	_btn1Day->onKeyboardPress((ActionHandler)&GeoscapeState::btnTimerClick, Options::keyGeoSpeed6);
 	_btn1Day->setGeoscapeButton(true);
+
+	// coop: ally-location markers. A white '+' is drawn, right-justified, in the
+	// top-right corner of a button for every OTHER player currently "there":
+	//  - their selected speed button while they are on the geoscape, or
+	//  - the toolbar button (Intercept/Bases/Graphs/Ufopaedia/Options/Funding)
+	//    they have navigated into. Two allies on the same button -> "++", etc.
+	// Added last so they draw on top of the buttons; updated each think() from the
+	// synced peer speed / focus (see updatePeerSpeedIndicators()).
+	TextButton* speedButtons[6] = { _btn5Secs, _btn1Min, _btn5Mins, _btn30Mins, _btn1Hour, _btn1Day };
+	TextButton* screenButtons[6] = { _btnIntercept, _btnBases, _btnGraphs, _btnUfopaedia, _btnOptions, _btnFunding };
+	for (int i = 0; i < 6; ++i)
+	{
+		_peerSpeedMarker[i] = new Text(speedButtons[i]->getWidth() - 2, 9, speedButtons[i]->getX(), speedButtons[i]->getY());
+		_peerScreenMarker[i] = new Text(screenButtons[i]->getWidth() - 2, 9, screenButtons[i]->getX(), screenButtons[i]->getY());
+
+		Text* markers[2] = { _peerSpeedMarker[i], _peerScreenMarker[i] };
+		for (Text* m : markers)
+		{
+			add(m, "text", "geoscape");
+			m->setSmall();
+			m->setAlign(ALIGN_RIGHT);
+			// White-ish; geoscape palette block 15 (240-255) is the grayscale/white
+			// ramp - tune this offset if the shade isn't right.
+			m->setColor(Palette::blockOffset(15) + 5);
+			m->setHighContrast(true);
+			m->setText("");
+		}
+	}
 
 	_sideBottom->setGeoscapeButton(true);
 	_sideTop->setGeoscapeButton(true);
@@ -944,7 +973,7 @@ void GeoscapeState::init()
 
 		if (connectionTCP::_host_save_progress == true && connectionTCP::getServerOwner() == false)
 		{
-			// If the player’s save file isn’t found, try to find the basehost file in memory.
+			// If the playerï¿½s save file isnï¿½t found, try to find the basehost file in memory.
 			if (!_game->getCoopMod()->hasCoopFile(coopKey))
 			{
 				coopKey = "basehost";
@@ -1691,6 +1720,9 @@ void GeoscapeState::think()
 		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
 	}
 
+	// coop: refresh the ally time-speed markers on the speed buttons.
+	updatePeerSpeedIndicators();
+
 	if (_popups.empty() && _dogfights.empty() && (!_zoomInEffectTimer->isRunning() || _zoomInEffectDone) && (!_zoomOutEffectTimer->isRunning() || _zoomOutEffectDone))
 	{
 		// Handle timers
@@ -1760,6 +1792,68 @@ void GeoscapeState::timeDisplay()
 	std::ostringstream ss5;
 	ss5 << _game->getSavedGame()->getTime()->getYear();
 	_txtYear->setText(ss5.str());
+}
+
+/**
+ * Updates the co-op ally-location markers: a right-justified '+' for every other
+ * player, on their selected speed button while they are on the geoscape, or on
+ * the toolbar button (Intercept/Bases/Graphs/Ufopaedia/Options/Funding) they are
+ * looking at. Only shown during a co-op session with time sync active.
+ */
+void GeoscapeState::updatePeerSpeedIndicators()
+{
+	int speedCounts[6] = { 0, 0, 0, 0, 0, 0 };
+	int screenCounts[6] = { 0, 0, 0, 0, 0, 0 };
+
+	if (_game->getCoopMod()->getCoopStatic() && connectionTCP::_enable_time_sync)
+	{
+		// peerFocusScreen: -1 = on the geoscape (use the selected speed), else the
+		// 0..5 toolbar-button index the peer has navigated into.
+		int screen = _game->getCoopMod()->peerFocusScreen.load();
+		if (screen >= 0 && screen < 6)
+		{
+			// One teammate for now; this naturally sums when more peers are added.
+			screenCounts[screen] += 1;
+		}
+		else
+		{
+			const std::string& id = _game->getCoopMod()->peerTimeSpeedId;
+			int idx = -1;
+			if (id == "_btn5Secs") idx = 0;
+			else if (id == "_btn1Min") idx = 1;
+			else if (id == "_btn5Mins") idx = 2;
+			else if (id == "_btn30Mins") idx = 3;
+			else if (id == "_btn1Hour") idx = 4;
+			else if (id == "_btn1Day") idx = 5;
+
+			if (idx >= 0) speedCounts[idx] += 1;
+		}
+	}
+
+	for (int i = 0; i < 6; ++i)
+	{
+		_peerSpeedMarker[i]->setText(std::string(speedCounts[i], '+'));
+		_peerScreenMarker[i]->setText(std::string(screenCounts[i], '+'));
+	}
+}
+
+/**
+ * Notifies the other player (in co-op) which geoscape sub-screen this player has
+ * navigated into, so their geoscape shows an ally marker on the matching toolbar
+ * button. screen is the 0..5 toolbar index (Intercept/Bases/Graphs/Ufopaedia/
+ * Options/Funding). Sent from the toolbar click handlers; if the click is
+ * actually rejected the player stays on the geoscape, so the next "time"
+ * heartbeat resets the peer's focus and a stray report self-corrects in a frame.
+ */
+void GeoscapeState::sendCoopFocus(int screen)
+{
+	if (!(_game->getCoopMod()->getCoopStatic() && connectionTCP::_enable_time_sync))
+		return;
+
+	Json::Value root;
+	root["state"] = "geo_focus";
+	root["screen"] = screen;
+	_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
 }
 
 /**
@@ -1890,6 +1984,20 @@ void GeoscapeState::timeAdvance()
 		}
 
 		_game->getCoopMod()->other_time_speed_coop = "";
+
+		// coop: freeze the authoritative host clock while the client is away from the
+		// geoscape (base, options, ufopaedia, intercept, popups, etc.). The client
+		// emits a "time" heartbeat every think() it spends on the geoscape; if the
+		// host hasn't seen one within the grace window, treat the client as paused.
+		// Combined with the host's own implicit pause (its GeoscapeState stops
+		// thinking inside a sub-state), this double-gates time: it advances only when
+		// BOTH players are on the geoscape, and resumes only once both return.
+		if (_game->getCoopMod()->getServerOwner())
+		{
+			const Uint32 grace = 1000; // ms; comfortably above the client's per-frame heartbeat gap
+			if (SDL_GetTicks() - _game->getCoopMod()->lastClientTimePacketMs.load() > grace)
+				timeSpan = 0;
+		}
 
 	}
 
@@ -4147,6 +4255,7 @@ void GeoscapeState::globeClick(Action *action)
  */
 void GeoscapeState::btnInterceptClick(Action *)
 {
+	sendCoopFocus(0); // coop: tell the ally we're looking at Intercept
 
 	// coop
 	if (connectionTCP::no_bases == true)
@@ -4263,6 +4372,7 @@ void GeoscapeState::btnDebugClick(Action *)
  */
 void GeoscapeState::btnBasesClick(Action *)
 {
+	sendCoopFocus(1); // coop: tell the ally we're looking at Bases
 
 	// coop
 	if (connectionTCP::no_bases == true)
@@ -4321,6 +4431,7 @@ void GeoscapeState::btnBasesClick(Action *)
  */
 void GeoscapeState::btnGraphsClick(Action *)
 {
+	sendCoopFocus(2); // coop: tell the ally we're looking at Graphs
 	if (buttonsDisabled())
 	{
 		return;
@@ -4334,6 +4445,7 @@ void GeoscapeState::btnGraphsClick(Action *)
  */
 void GeoscapeState::btnUfopaediaClick(Action *)
 {
+	sendCoopFocus(3); // coop: tell the ally we're looking at Ufopaedia
 	if (buttonsDisabled())
 	{
 		return;
@@ -4347,6 +4459,7 @@ void GeoscapeState::btnUfopaediaClick(Action *)
  */
 void GeoscapeState::btnOptionsClick(Action *)
 {
+	sendCoopFocus(4); // coop: tell the ally we're looking at Options
 	if (buttonsDisabled())
 	{
 		return;
@@ -4360,6 +4473,7 @@ void GeoscapeState::btnOptionsClick(Action *)
  */
 void GeoscapeState::btnFundingClick(Action *)
 {
+	sendCoopFocus(5); // coop: tell the ally we're looking at Funding
 	if (buttonsDisabled())
 	{
 		return;

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -365,13 +365,14 @@ GeoscapeState::GeoscapeState() : _pause(false), _zoomInEffectDone(false), _zoomO
 	_btn1Day->onKeyboardPress((ActionHandler)&GeoscapeState::btnTimerClick, Options::keyGeoSpeed6);
 	_btn1Day->setGeoscapeButton(true);
 
-	// coop: ally-location markers. A white '+' is drawn, right-justified, in the
-	// top-right corner of a button for every OTHER player currently "there":
+	// coop: ally-location markers. A '+' is drawn, right-justified, in the top-right
+	// corner of a button for every OTHER player currently "there":
 	//  - their selected speed button while they are on the geoscape, or
 	//  - the toolbar button (Intercept/Bases/Graphs/Ufopaedia/Options/Funding)
 	//    they have navigated into. Two allies on the same button -> "++", etc.
-	// Added last so they draw on top of the buttons; updated each think() from the
-	// synced peer speed / focus (see updatePeerSpeedIndicators()).
+	// Colour/contrast are (re)applied every think() in updatePeerSpeedIndicators():
+	// "red" (blockOffset(15)+5, high contrast) for an active ally, yellow for a busy
+	// one. Added last so they draw on top of the buttons.
 	TextButton* speedButtons[6] = { _btn5Secs, _btn1Min, _btn5Mins, _btn30Mins, _btn1Hour, _btn1Day };
 	TextButton* screenButtons[6] = { _btnIntercept, _btnBases, _btnGraphs, _btnUfopaedia, _btnOptions, _btnFunding };
 	for (int i = 0; i < 6; ++i)
@@ -385,8 +386,7 @@ GeoscapeState::GeoscapeState() : _pause(false), _zoomInEffectDone(false), _zoomO
 			add(m, "text", "geoscape");
 			m->setSmall();
 			m->setAlign(ALIGN_RIGHT);
-			// White-ish; geoscape palette block 15 (240-255) is the grayscale/white
-			// ramp - tune this offset if the shade isn't right.
+			// Initial look; updatePeerSpeedIndicators() overrides colour/contrast each think.
 			m->setColor(Palette::blockOffset(15) + 5);
 			m->setHighContrast(true);
 			m->setText("");
@@ -1716,7 +1716,14 @@ void GeoscapeState::think()
 		{
 			root["time_speed"] = "_btn1Day";
 		}
-		
+
+		// coop: report on-geoscape focus for the ally marker. -1 = normal geoscape
+		// (marker on the speed button); 0 = an open dogfight window (marker -> Intercept).
+		// Dogfights deliberately keep time running, so we report focus here rather than
+		// freezing. Sub-screens stop these packets, so their dedicated geo_focus sticks.
+		bool inDogfight = _minimizedDogfights < _dogfights.size();
+		root["geo_focus"] = inDogfight ? 0 : -1;
+
 		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
 	}
 
@@ -1744,6 +1751,13 @@ void GeoscapeState::think()
 		{
 			// Handle popups
 			_globe->rotateStop();
+			// coop: move the ally marker to the toolbar button matching this popup
+			// (UFO/mission/alien base -> Intercept, base/research events -> Bases,
+			// monthly report -> Funding). Unmapped popups send nothing and let the
+			// marker stay yellow (busy).
+			int focus = coopFocusForPopup(_popups.front());
+			if (focus >= 0)
+				sendCoopFocus(focus);
 			_game->pushState(_popups.front());
 			_popups.erase(_popups.begin());
 		}
@@ -1804,6 +1818,7 @@ void GeoscapeState::updatePeerSpeedIndicators()
 {
 	int speedCounts[6] = { 0, 0, 0, 0, 0, 0 };
 	int screenCounts[6] = { 0, 0, 0, 0, 0, 0 };
+	bool speedBusy[6] = { false, false, false, false, false, false };
 
 	if (_game->getCoopMod()->getCoopStatic() && connectionTCP::_enable_time_sync)
 	{
@@ -1826,14 +1841,35 @@ void GeoscapeState::updatePeerSpeedIndicators()
 			else if (id == "_btn1Hour") idx = 4;
 			else if (id == "_btn1Day") idx = 5;
 
-			if (idx >= 0) speedCounts[idx] += 1;
+			if (idx >= 0)
+			{
+				speedCounts[idx] += 1;
+				// Mark the ally "busy" (yellow) when they are away from the geoscape (no
+				// recent heartbeat) with no known sub-screen: time is frozen and we don't
+				// know where they went. Same grace as the host's freeze gate, so the
+				// marker turns yellow exactly when time stops.
+				const Uint32 grace = 1000;
+				if (SDL_GetTicks() - _game->getCoopMod()->lastPeerTimePacketMs.load() > grace)
+					speedBusy[idx] = true;
+			}
 		}
 	}
+
+	const Uint8 markerRed = Palette::blockOffset(15) + 5;     // active ally ("red"/pink)
+	const Uint8 markerYellow = Palette::blockOffset(15) + 10; // busy ally (renders yellow); tunable
 
 	for (int i = 0; i < 6; ++i)
 	{
 		_peerSpeedMarker[i]->setText(std::string(speedCounts[i], '+'));
+		_peerSpeedMarker[i]->setColor(speedBusy[i] ? markerYellow : markerRed);
+		// Busy (yellow) markers use low contrast so the anti-aliased edge pixels stay
+		// close to the base colour instead of jumping to the cyan palette entries that
+		// high contrast's wider shade spread lands on. Active "red" markers keep high contrast.
+		_peerSpeedMarker[i]->setHighContrast(!speedBusy[i]);
+
 		_peerScreenMarker[i]->setText(std::string(screenCounts[i], '+'));
+		_peerScreenMarker[i]->setColor(markerRed);
+		_peerScreenMarker[i]->setHighContrast(true);
 	}
 }
 
@@ -1854,6 +1890,41 @@ void GeoscapeState::sendCoopFocus(int screen)
 	root["state"] = "geo_focus";
 	root["screen"] = screen;
 	_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+}
+
+/**
+ * Maps an event popup about to be shown to the co-op ally-marker toolbar button:
+ * 0 = Intercept (UFO / mission / alien base), 1 = Bases (base defense plus base
+ * and research/production events), 5 = Funding (monthly report). Returns -1 for
+ * popups with no meaningful mapping (errors, cutscenes, craft dialogs, random
+ * events), so the ally marker stays yellow (busy) instead.
+ */
+int GeoscapeState::coopFocusForPopup(State* state)
+{
+	if (dynamic_cast<UfoDetectedState*>(state)
+		|| dynamic_cast<MissionDetectedState*>(state)
+		|| dynamic_cast<AlienBaseState*>(state))
+		return 0; // INTERCEPT
+
+	if (dynamic_cast<BaseDefenseState*>(state)
+		|| dynamic_cast<ProductionCompleteState*>(state)
+		|| dynamic_cast<ResearchCompleteState*>(state)
+		|| dynamic_cast<ResearchRequiredState*>(state)
+		|| dynamic_cast<NewPossibleResearchState*>(state)
+		|| dynamic_cast<NewPossibleManufactureState*>(state)
+		|| dynamic_cast<NewPossiblePurchaseState*>(state)
+		|| dynamic_cast<NewPossibleCraftState*>(state)
+		|| dynamic_cast<NewPossibleFacilityState*>(state)
+		|| dynamic_cast<SellState*>(state)
+		|| dynamic_cast<ManageAlienContainmentState*>(state)
+		|| dynamic_cast<TrainingFinishedState*>(state)
+		|| dynamic_cast<ItemsArrivingState*>(state))
+		return 1; // BASES
+
+	if (dynamic_cast<MonthlyReportState*>(state))
+		return 5; // FUNDING
+
+	return -1; // no meaningful mapping -> leave the marker yellow (busy)
 }
 
 /**
@@ -1995,7 +2066,7 @@ void GeoscapeState::timeAdvance()
 		if (_game->getCoopMod()->getServerOwner())
 		{
 			const Uint32 grace = 1000; // ms; comfortably above the client's per-frame heartbeat gap
-			if (SDL_GetTicks() - _game->getCoopMod()->lastClientTimePacketMs.load() > grace)
+			if (SDL_GetTicks() - _game->getCoopMod()->lastPeerTimePacketMs.load() > grace)
 				timeSpan = 0;
 		}
 
@@ -4227,6 +4298,21 @@ void GeoscapeState::globeClick(Action *action)
 		std::vector<Target*> v = _globe->getTargets(mouseX, mouseY, false, 0);
 		if (!v.empty())
 		{
+			// coop: report what the ally clicked. Only the OTHER player's base
+			// (_coopBase) -> Bases; your own base opens the intercept window, so it
+			// (like UFOs / craft / mission sites) -> Intercept.
+			int focus = 0; // INTERCEPT
+			for (Target* t : v)
+			{
+				Base* b = dynamic_cast<Base*>(t);
+				if (b && b->_coopBase)
+				{
+					focus = 1; // BASES
+					break;
+				}
+			}
+			sendCoopFocus(focus);
+
 			// Pass empty vector
 			std::vector<Craft*> crafts;
 			_game->pushState(new MultipleTargetsState(v, crafts, this, true));

--- a/src/Geoscape/GeoscapeState.h
+++ b/src/Geoscape/GeoscapeState.h
@@ -198,6 +198,8 @@ public:
 	void updatePeerSpeedIndicators();
 	/// Tells the other player which geoscape sub-screen this player navigated to (0..5).
 	void sendCoopFocus(int screen);
+	/// Maps an event popup to the ally-marker toolbar button (0..5), or -1 to leave it yellow (busy).
+	int coopFocusForPopup(State *state);
 	/// Process a mission site
 	bool processMissionSite(MissionSite *site);
 	/// Handles base defense

--- a/src/Geoscape/GeoscapeState.h
+++ b/src/Geoscape/GeoscapeState.h
@@ -54,6 +54,12 @@ private:
 	TextButton *_sideTop, *_sideBottom;
 	InteractiveSurface *_btnRotateLeft, *_btnRotateRight, *_btnRotateUp, *_btnRotateDown, *_btnZoomIn, *_btnZoomOut;
 	Text *_txtFunds, *_txtHour, *_txtHourSep, *_txtMin, *_txtMinSep, *_txtSec, *_txtWeekday, *_txtDay, *_txtMonth, *_txtYear;
+	// coop: ally-location markers ('+' per other player). _peerSpeedMarker is indexed
+	// 0..5 = 5 Secs / 1 Min / 5 Mins / 30 Mins / 1 Hour / 1 Day (shown while the peer is
+	// on the geoscape). _peerScreenMarker is indexed 0..5 = Intercept / Bases / Graphs /
+	// Ufopaedia / Options / Funding (shown while the peer is looking at that screen).
+	Text *_peerSpeedMarker[6];
+	Text *_peerScreenMarker[6];
 	Timer *_gameTimer, *_zoomInEffectTimer, *_zoomOutEffectTimer, *_dogfightStartTimer, *_dogfightTimer;
 	bool _pause, _zoomInEffectDone, _zoomOutEffectDone;
 	Text *_txtDebug;
@@ -188,6 +194,10 @@ public:
 	int getFirstFreeDogfightSlot();
 	/// Handler for clicking the timer button.
 	void btnTimerClick(Action *action);
+	/// Updates the co-op ally markers on the speed/toolbar buttons.
+	void updatePeerSpeedIndicators();
+	/// Tells the other player which geoscape sub-screen this player navigated to (0..5).
+	void sendCoopFocus(int screen);
 	/// Process a mission site
 	bool processMissionSite(MissionSite *site);
 	/// Handles base defense


### PR DESCRIPTION
## Summary
Two related co-op quality-of-life improvements for the geoscape.

### See what your ally is doing
A marker (a `+` per other player) in the top-right corner of a geoscape button
shows where your teammate's attention is:
- **Their selected time speed** while they're on the geoscape, so you can match
  speeds (time only advances when both players pick the same speed).

<img width="462" height="305" alt="image" src="https://github.com/user-attachments/assets/568c5882-cbea-4385-a26c-7e4088fabb22" />

- **The toolbar screen they're in** — Bases / Ufopaedia / Intercept / Graphs /
  Options / Funding — including **Intercept** when they click or are handling a
  UFO or are in a dogfight, and **Bases** when they're viewing the other
  player's base.

<img width="462" height="517" alt="image" src="https://github.com/user-attachments/assets/6a727520-b081-4e92-ab40-d91c5046fd26" />

- If they're away on something with no specific screen (a popup, cutscene,
  random event…), the marker dims to **yellow** to show they're busy.

<img width="462" height="305" alt="image" src="https://github.com/user-attachments/assets/0df0bd0d-f084-46ee-9d60-d3ac70a2b1fd" />

It's a per-button count, so it extends naturally to more players (one `+` each).

### Two-way time freeze
The geoscape clock froze for the client when the host left the geoscape, but not
the reverse. Now the host's authoritative clock also freezes while the *client*
is away. The client emits a per-frame "time" heartbeat; if the host stops seeing
it, it stops advancing. Combined with the host's own implicit pause, time runs
only while both players are on the geoscape and resumes once both return.
Dogfights deliberately keep time running.

## Notes
- A `geo_focus` field on the "time" packet (plus a dedicated packet on
  navigation) tracks where the peer is; a symmetric heartbeat drives both the
  freeze and the busy state. Popup → button mapping lives in one place
  (`coopFocusForPopup`). No new files — changes are confined to `GeoscapeState`
  and the co-op `connectionTCP` object.

## Testing
Built Release | x64 (VS 2022) and manually verified in a host+client session: matching
speeds advance time; either player entering a base/options/popup freezes both;
the marker tracks the ally to the right button and turns yellow when busy;
dogfights keep time running and show Intercept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)