### PR TITLE
Fix motion scanner for second player, synchronize motion-scanned enemy positions, and allow ALT soldier direction/motion scan viewing for off-turn player

### DIFF
--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -727,12 +727,9 @@ void Map::drawUnit(UnitSprite &unitSprite, Tile *unitTile, Tile *currTile, Posit
 		shade = std::min(+NIGHT_VISION_SHADE, shade);
 	}
 
-	// coop
-	if (_game->getCoopMod()->getCurrentTurn() == 1)
-	{
-		_isAltPressed = false;
-		_isCtrlPressed = false;
-	}
+	// coop: ALT facing-indicator and motion-scanner arrows are read-only observer
+	// visuals, so allow them during the off-turn player's view too (previously this
+	// forced _isAltPressed/_isCtrlPressed false when it wasn't our turn).
 
 	unitSprite.draw(bu, part, tileScreenPosition.x + offsets.ScreenOffset.x, tileScreenPosition.y + offsets.ScreenOffset.y, shade, mask, _isAltPressed && !_isCtrlPressed);
 }

--- a/src/Battlescape/ScannerView.cpp
+++ b/src/Battlescape/ScannerView.cpp
@@ -25,6 +25,7 @@
 #include "../Savegame/Tile.h"
 #include "../Savegame/SavedGame.h"
 #include "../Savegame/SavedBattleGame.h"
+#include "../CoopMod/connectionTCP.h"
 
 namespace OpenXcom
 {
@@ -66,7 +67,20 @@ void ScannerView::draw()
 					int frame = (t->getUnit()->getMotionPoints() / 5);
 					if (frame >= 0)
 					{
-						t->getUnit()->setScannedTurn(_game->getSavedGame()->getSavedBattle()->getTurn());
+						BattleUnit *scannedUnit = t->getUnit();
+						int curTurn = _game->getSavedGame()->getSavedBattle()->getTurn();
+						// coop: tell the other player about a newly-scanned unit so its
+						// motion-scanner marker shows on their map too (sent once per unit
+						// per turn, when scannedTurn changes).
+						if (connectionTCP::getCoopStatic() && scannedUnit->getScannedTurn() != curTurn)
+						{
+							Json::Value root;
+							root["state"] = "motion_scan";
+							root["unit_id"] = scannedUnit->getId();
+							root["turn"] = curTurn;
+							_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+						}
+						scannedUnit->setScannedTurn(curTurn);
 						if (frame > 5) frame = 5;
 						surface = set->getFrame(frame + _frame);
 						surface->blitNShade(this, ((9+x)*8)-4, ((9+y)*8)-4, 0);

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -2141,9 +2141,27 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 	}
 
+	if (stateString == "motion_scan")
+	{
+		if (_game->getSavedGame() && _game->getSavedGame()->getSavedBattle())
+		{
+			int unit_id = obj["unit_id"].asInt();
+			int turn = obj["turn"].asInt();
+
+			for (auto& unit : *_game->getSavedGame()->getSavedBattle()->getUnits())
+			{
+				if (unit->getId() == unit_id)
+				{
+					unit->setScannedTurn(turn);
+					break;
+				}
+			}
+		}
+	}
+
 	if (stateString == "abortPath")
 	{
-	
+
 		int unit_id = obj["unit_id"].asInt();
 
 		int x = obj["x"].asInt();
@@ -3717,7 +3735,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 							int mana = obj["units"][i]["mana"].asInt();
 							int stunlevel = obj["units"][i]["stunlevel"].asInt();
 
-							int motionpoints = obj["motionpoints"].asInt();
+							int motionpoints = obj["units"][i]["motionpoints"].asInt();
 
 							int setDirection = obj["units"][i]["setDirection"].asInt();
 							int setFaceDirection = obj["units"][i]["setFaceDirection"].asInt();
@@ -5321,7 +5339,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 								int mana = obj["units"][i]["mana"].asInt();
 								int stunlevel = obj["units"][i]["stunlevel"].asInt();
 								bool is_out = obj["units"][i]["is_out"].asBool();
-								int motionpoints = obj["motionpoints"].asInt();
+								int motionpoints = obj["units"][i]["motionpoints"].asInt();
 
 								int setDirection = obj["units"][i]["setDirection"].asInt();
 								int setFaceDirection = obj["units"][i]["setFaceDirection"].asInt();


### PR DESCRIPTION
ALT-held facing-direction arrows (and motion-scanner markers) were suppressed for the off-turn player: the per-unit draw in Map.cpp forced the ALT/CTRL modifier state to false whenever it was not the local player's turn. These are read-only observer visuals, so allow them during the off-turn view too.

Add a "motion_scan" TCP packet so that when one player's motion scanner detects a unit, the other player's map shows the same marker.

Fix motion points not syncing to the second player in a co-op turn: the "PlayerTurnYour" and "current_seed" receivers read motionpoints from the top-level JSON object instead of the per-unit element, so every unit was set to 0 motion points on turn handover, leaving the second player's motion scanner blind to enemies that moved.