### PR TITLE
Fix co-op off-turn cursor being incorrectly set/persisted to aim cursor

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -1899,6 +1899,15 @@ void BattlescapeGame::endBattleTurnCoop()
  */
 void BattlescapeGame::setupCursor()
 {
+	// coop: while it's not our turn, the active player's synced actions must not
+	// drive our cursor (e.g. a teammate firing would otherwise flip us to CT_AIM).
+	// Keep the standard box cursor for the off-turn player.
+	if (getCoopMod()->getCoopStatic() && isYourTurn != 2 && isYourTurn != 0)
+	{
+		getMap()->setCursorType(CT_NORMAL);
+		return;
+	}
+
 	if (_currentAction.targeting)
 	{
 		if (_currentAction.type == BA_THROW)

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -2901,6 +2901,11 @@ void BattlescapeState::btnEndTurnClick(Action *)
 		_game->getCoopMod()->setPlayerTurn(1);
 		_battleGame->isYourTurn = 1;
 
+		// coop end-turn hands off without running BattlescapeGame::endTurn (which
+		// normally clears targeting and resets the cursor), so an aiming cursor
+		// would otherwise persist into the off-turn view. Reset it here.
+		_battleGame->cancelCurrentActionCoop(true);
+
 		int actor_jd = -1;
 
 		if (_save->getSelectedUnit())


### PR DESCRIPTION
Two co-op bugs where the off-turn player's cursor was wrongly driven into the aiming (CT_AIM) state instead of the standard box cursor.

1. Ending a turn with the aiming cursor out: the co-op end-turn handoff in BattlescapeState::btnEndTurnClick sets is_return=true and skips requestEndTurn(), so BattlescapeGame::endTurn() (which normally clears targeting and resets the cursor) never runs for the ending player. Reset it explicitly via cancelCurrentActionCoop(true) after the handoff.

2. A teammate firing: at the end of a synced shot ProjectileFlyBState calls setupCursor() when getSide()==FACTION_PLAYER, which is still true for the off-turn co-op client, flipping its cursor to CT_AIM. Guard setupCursor() so that while it is not our turn (coop && isYourTurn != 2) it keeps the normal box cursor and ignores the active player's action. This also covers throw/psi/launch actions.