### PR TITLE
Fix coop double-spawn of chrysalid from convertUnit packet race

### DIFF
--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -2171,7 +2171,15 @@ BattleUnit *SavedBattleGame::createTempUnit(const Unit *rules, UnitFaction facti
  */
 BattleUnit *SavedBattleGame::convertUnit(BattleUnit *unit)
 {
-	// only ever respawn once
+	// only ever respawn once. The guard normally lives at the callers, but in
+	// coop the convertUnit network packet handler and the local (coop_death)
+	// UnitDieBState both call this for the same zombie and can race, spawning
+	// two chrysalids on the observing player. Enforce it here too so the loser
+	// of that race is a no-op instead of an orphan unit that stands frozen.
+	if (unit->getAlreadyRespawned())
+	{
+		return nullptr;
+	}
 	unit->setAlreadyRespawned(true);
 
 	bool visible = unit->getVisible();


### PR DESCRIPTION
Summary: Fixes a co-op bug where killing a chrysalid-spawning zombie and its resulting chrysalid in the same auto-shot leaves a frozen, immortal chrysalid on the observing player's screen for the rest of the mission.

Root cause: Both the convertUnit network-packet handler (connectionTCP.cpp) and the local coop-death UnitDieBState::think() call SavedBattleGame::convertUnit for the same dying zombie. The respawn-only-once guard lived only at the callers; the packet handler was unguarded. When the local death state wins the race, the packet handler spawns a second chrysalid that never receives a death packet — it stands frozen and desyncs subsequent unit IDs. Timing-dependent, hence the same-auto-shot trigger.

Fix: Enforce the guard inside SavedBattleGame::convertUnit (the chokepoint both paths share); the race loser becomes a no-op (return nullptr). Callers already null-check or ignore the return.

Validated manually in 2-player co-op; both units now die correctly on both screens.