### PR TITLE
Add text labels and usable defaults to host/connect dialogs

### DIFF
--- a/src/CoopMod/CoopMenu.cpp
+++ b/src/CoopMod/CoopMenu.cpp
@@ -172,7 +172,7 @@ CoopMenu::CoopMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	_playerName->setColor(color);
 	_playerName->setBig();
 	_playerName->setBorderColor(color);
-	_playerName->setText("Player");
+	_playerName->setText(_game->getCoopMod()->getHostName());
 	_playerName->setVisible(false);
 
 	_btnMessage->setText("DISCONNECT");
@@ -291,68 +291,42 @@ CoopMenu::CoopMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 
 	}
 
-	// READ IP ADDRESS
-
-	// Name of the JSON file
-	std::string filename = "ip_address.json";
-	std::string filepath = Options::getMasterUserFolder() + filename;
+	// READ CLIENT ADDRESS
 
 	std::string ipAddress;
 	std::string port;
-	std::string playerName;
 
-	if (OpenXcom::CrossPlatform::fileExists(filepath))
 	{
-		std::ifstream file(filepath, std::ifstream::binary);
-		if (file.is_open())
+		std::string filepath = Options::getMasterUserFolder() + "client_address.json";
+
+		if (OpenXcom::CrossPlatform::fileExists(filepath))
 		{
-			Json::Value root;
-			Json::CharReaderBuilder builder;
-			std::string errs;
-
-			bool parsingSuccessful = Json::parseFromStream(builder, file, &root, &errs);
-			file.close();
-
-			if (parsingSuccessful)
+			std::ifstream file(filepath, std::ifstream::binary);
+			if (file.is_open())
 			{
-				ipAddress = root.get("ip", "").asString();
-				port = root.get("port", "").asString();
-				playerName = root.get("name", "").asString();
+				Json::Value root;
+				Json::CharReaderBuilder builder;
+				std::string errs;
 
-				
-				if (ipAddress.empty())
+				bool parsingSuccessful = Json::parseFromStream(builder, file, &root, &errs);
+				file.close();
+
+				if (parsingSuccessful)
 				{
-					// ip is empty
-					ipAddress = "IP-ADDRESS";
+					ipAddress = root.get("ip", "").asString();
+					port = root.get("port", "").asString();
 				}
-
-				if (port == "")
-				{
-					// port is empty
-					port = "3000";
-				}
-
-
-				if (playerName == "")
-				{
-					// name is empty
-					playerName = "Player";
-				}
-
-				_ipAddress->setText(ipAddress);
-				_port->setText(port);
-				_playerName->setText(playerName); 
 			}
-			else
-			{
-				std::cerr << "Failed to parse JSON: " << errs << std::endl;
-			}
-		}
-		else
-		{
-			std::cerr << "Failed to open the file." << std::endl;
 		}
 	}
+
+	if (ipAddress.empty())
+		ipAddress = "IP-ADDRESS";
+	if (port.empty())
+		port = "3000";
+
+	_ipAddress->setText(ipAddress);
+	_port->setText(port);
 
 }
 

--- a/src/CoopMod/DirectConnect.cpp
+++ b/src/CoopMod/DirectConnect.cpp
@@ -38,19 +38,24 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	int x = 20;
 	
 	// Create objects
-	_window = new Window(this, 216, 160, x, 20, POPUP_BOTH);
+	_window = new Window(this, 260, 160, x, 20, POPUP_BOTH);
 
-	_cbxNetworkProtocol = new ComboBox(this, 180, 18, x + 18, 50);
-	_ipAddress = new TextEdit(this, 180, 18, x + 18, 72);
-	_port = new TextEdit(this, 180, 18, x + 18, 92);
-	_playerName = new TextEdit(this, 180, 18, x + 18, 112);
+	_cbxNetworkProtocol = new ComboBox(this, 224, 18, x + 18, 50);
 
-	_tcpButtonJoin = new TextButton(180, 18, x + 18, 132);
+	_lblHostIp = new Text(100, 18, x + 18, 72);
+	_lblPort = new Text(100, 18, x + 18, 92);
+	_lblPlayerName = new Text(100, 18, x + 18, 112);
 
-	_txtInfo = new Text(180, 18, x + 18, 95);
-	_btnCancel = new TextButton(180, 18, x + 18, 152);
-	_txtData = new Text(206, 17, x + 5, 50);
-	_txtTitle = new Text(206, 17, x + 5, 32);
+	_ipAddress = new TextEdit(this, 124, 18, x + 118, 72);
+	_port = new TextEdit(this, 124, 18, x + 118, 92);
+	_playerName = new TextEdit(this, 124, 18, x + 118, 112);
+
+	_tcpButtonJoin = new TextButton(224, 18, x + 18, 132);
+
+	_txtInfo = new Text(224, 18, x + 18, 95);
+	_btnCancel = new TextButton(224, 18, x + 18, 152);
+	_txtData = new Text(250, 17, x + 5, 50);
+	_txtTitle = new Text(250, 17, x + 5, 32);
 
 	int screenWidth = Options::baseXGeoscape;
 	int screenHeight = Options::baseYGeoscape;
@@ -59,9 +64,12 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	setInterface("pauseMenu", false, _game->getSavedGame() ? _game->getSavedGame()->getSavedBattle() : 0);
 
 	add(_window, "window", "pauseMenu");
-	add(_ipAddress);
-	add(_port);
-	add(_playerName);
+	add(_lblHostIp, "text", "pauseMenu");
+	add(_lblPort, "text", "pauseMenu");
+	add(_lblPlayerName, "text", "pauseMenu");
+	add(_ipAddress, "text", "pauseMenu");
+	add(_port, "text", "pauseMenu");
+	add(_playerName, "text", "pauseMenu");
 	add(_tcpButtonJoin, "button", "pauseMenu");
 	add(_cbxNetworkProtocol, "button", "pauseMenu");
 	add(_txtInfo, "text", "pauseMenu");
@@ -106,26 +114,47 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	_cbxNetworkProtocol->setOptions(_networkProtocolTypes, false);
 	_cbxNetworkProtocol->onChange((ActionHandler)&DirectConnect::cbxNetworkProtocolChange);
 
+	// labels
+	_lblHostIp->setBig();
+	_lblHostIp->setBorderColor(color);
+	_lblHostIp->setText("HOST IP>");
+	_lblHostIp->setVisible(false);
+
+	_lblPort->setBig();
+	_lblPort->setBorderColor(color);
+	_lblPort->setText("PORT>");
+	_lblPort->setVisible(false);
+
+	_lblPlayerName->setBig();
+	_lblPlayerName->setBorderColor(color);
+	_lblPlayerName->setText("USERNAME>");
+	_lblPlayerName->setVisible(false);
+
 	// ip address
 	_ipAddress->setColor(color);
 	_ipAddress->setBig();
 	_ipAddress->setBorderColor(color);
-	_ipAddress->setText("IP-ADDRESS");
+	_ipAddress->setAllowOverflow(true);
+	_ipAddress->setText("127.0.0.1");
 	_ipAddress->setVisible(false);
 
 	// port
 	_port->setColor(color);
 	_port->setBig();
 	_port->setBorderColor(color);
-	_port->setText("PORT");
+	_port->setConstraint(TEC_NUMERIC_POSITIVE);
+	_port->setAllowOverflow(true);
+	_port->setText("61008");
 	_port->setVisible(false);
 
 	_playerName->setColor(color);
 	_playerName->setBig();
 	_playerName->setBorderColor(color);
-	_playerName->setText(_game->getCoopMod()->getHostName());
+	_playerName->setAllowOverflow(true);
+	_playerName->setText("Jane Kelly");
 	_playerName->setVisible(false);
 	_playerName->onChange((ActionHandler)&DirectConnect::edtPlayerNameChange);
+	_game->getCoopMod()->setHostName("Jane Kelly");
 	
 	_tcpButtonJoin->setText("JOIN");
 	_tcpButtonJoin->onMouseClick((ActionHandler)&DirectConnect::joinTCPGame);
@@ -149,8 +178,11 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 
 	if (_game->getCoopMod()->isConnected() == 1)
 	{
+		_lblHostIp->setVisible(false);
 		_ipAddress->setVisible(false);
+		_lblPort->setVisible(false);
 		_port->setVisible(false);
+		_lblPlayerName->setVisible(false);
 		_playerName->setVisible(false);
 		_tcpButtonJoin->setVisible(false);
 		_txtInfo->setVisible(false);
@@ -158,8 +190,11 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	}
 	else if (_game->getCoopMod()->isConnected() == -1)
 	{
+		_lblHostIp->setVisible(true);
 		_ipAddress->setVisible(true);
+		_lblPort->setVisible(true);
 		_port->setVisible(true);
+		_lblPlayerName->setVisible(true);
 		_playerName->setVisible(true);
 		_tcpButtonJoin->setVisible(true);
 		_txtInfo->setVisible(false);
@@ -198,25 +233,26 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 				if (ipAddress.empty())
 				{
 					// ip is empty
-					ipAddress = "IP-ADDRESS";
+					ipAddress = "127.0.0.1";
 				}
 
 				if (port == "")
 				{
 					// port is empty
-					port = "3000";
+					port = "61008";
 				}
 
 
 				if (playerName == "")
 				{
 					// name is empty
-					playerName = "Player";
+					playerName = "Jane Kelly";
 				}
 
 				_ipAddress->setText(ipAddress);
 				_port->setText(port);
-				_playerName->setText(playerName); 
+				_playerName->setText(playerName);
+				_game->getCoopMod()->setHostName(playerName); 
 			}
 			else
 			{
@@ -247,8 +283,11 @@ void DirectConnect::init()
 
 	if (_game->getCoopMod()->isConnected() == 1)
 	{
+		_lblHostIp->setVisible(false);
 		_ipAddress->setVisible(false);
+		_lblPort->setVisible(false);
 		_port->setVisible(false);
+		_lblPlayerName->setVisible(false);
 		_playerName->setVisible(false);
 		_tcpButtonJoin->setVisible(false);
 		_txtInfo->setVisible(false);
@@ -258,8 +297,11 @@ void DirectConnect::init()
 	}
 	else if (_game->getCoopMod()->isConnected() == -1)
 	{
+		_lblHostIp->setVisible(true);
 		_ipAddress->setVisible(true);
+		_lblPort->setVisible(true);
 		_port->setVisible(true);
+		_lblPlayerName->setVisible(true);
 		_playerName->setVisible(true);
 		_tcpButtonJoin->setVisible(true);
 		_txtInfo->setVisible(false);

--- a/src/CoopMod/DirectConnect.cpp
+++ b/src/CoopMod/DirectConnect.cpp
@@ -44,16 +44,14 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 
 	_lblHostIp = new Text(100, 18, x + 18, 72);
 	_lblPort = new Text(100, 18, x + 18, 92);
-	_lblPlayerName = new Text(100, 18, x + 18, 112);
 
 	_ipAddress = new TextEdit(this, 124, 18, x + 118, 72);
 	_port = new TextEdit(this, 124, 18, x + 118, 92);
-	_playerName = new TextEdit(this, 124, 18, x + 118, 112);
 
-	_tcpButtonJoin = new TextButton(224, 18, x + 18, 132);
+	_tcpButtonJoin = new TextButton(224, 18, x + 18, 112);
 
 	_txtInfo = new Text(224, 18, x + 18, 95);
-	_btnCancel = new TextButton(224, 18, x + 18, 152);
+	_btnCancel = new TextButton(224, 18, x + 18, 132);
 	_txtData = new Text(250, 17, x + 5, 50);
 	_txtTitle = new Text(250, 17, x + 5, 32);
 
@@ -66,10 +64,8 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	add(_window, "window", "pauseMenu");
 	add(_lblHostIp, "text", "pauseMenu");
 	add(_lblPort, "text", "pauseMenu");
-	add(_lblPlayerName, "text", "pauseMenu");
 	add(_ipAddress, "text", "pauseMenu");
 	add(_port, "text", "pauseMenu");
-	add(_playerName, "text", "pauseMenu");
 	add(_tcpButtonJoin, "button", "pauseMenu");
 	add(_cbxNetworkProtocol, "button", "pauseMenu");
 	add(_txtInfo, "text", "pauseMenu");
@@ -125,11 +121,6 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	_lblPort->setText("PORT>");
 	_lblPort->setVisible(false);
 
-	_lblPlayerName->setBig();
-	_lblPlayerName->setBorderColor(color);
-	_lblPlayerName->setText("USERNAME>");
-	_lblPlayerName->setVisible(false);
-
 	// ip address
 	_ipAddress->setColor(color);
 	_ipAddress->setBig();
@@ -146,15 +137,6 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 	_port->setAllowOverflow(true);
 	_port->setText("61008");
 	_port->setVisible(false);
-
-	_playerName->setColor(color);
-	_playerName->setBig();
-	_playerName->setBorderColor(color);
-	_playerName->setAllowOverflow(true);
-	_playerName->setText("Jane Kelly");
-	_playerName->setVisible(false);
-	_playerName->onChange((ActionHandler)&DirectConnect::edtPlayerNameChange);
-	_game->getCoopMod()->setHostName("Jane Kelly");
 	
 	_tcpButtonJoin->setText("JOIN");
 	_tcpButtonJoin->onMouseClick((ActionHandler)&DirectConnect::joinTCPGame);
@@ -182,8 +164,6 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 		_ipAddress->setVisible(false);
 		_lblPort->setVisible(false);
 		_port->setVisible(false);
-		_lblPlayerName->setVisible(false);
-		_playerName->setVisible(false);
 		_tcpButtonJoin->setVisible(false);
 		_txtInfo->setVisible(false);
 	
@@ -194,76 +174,47 @@ DirectConnect::DirectConnect() : _craft(0), _selectType(NewBattleSelectType::MIS
 		_ipAddress->setVisible(true);
 		_lblPort->setVisible(true);
 		_port->setVisible(true);
-		_lblPlayerName->setVisible(true);
-		_playerName->setVisible(true);
 		_tcpButtonJoin->setVisible(true);
 		_txtInfo->setVisible(false);
 
 	}
 
-	// READ IP ADDRESS
-
-	// Name of the JSON file
-	std::string filename = "ip_address.json";
-	std::string filepath = Options::getMasterUserFolder() + filename;
+	// READ CLIENT ADDRESS
 
 	std::string ipAddress;
 	std::string port;
-	std::string playerName;
 
-	if (OpenXcom::CrossPlatform::fileExists(filepath))
 	{
-		std::ifstream file(filepath, std::ifstream::binary);
-		if (file.is_open())
+		std::string filepath = Options::getMasterUserFolder() + "client_address.json";
+
+		if (OpenXcom::CrossPlatform::fileExists(filepath))
 		{
-			Json::Value root;
-			Json::CharReaderBuilder builder;
-			std::string errs;
-
-			bool parsingSuccessful = Json::parseFromStream(builder, file, &root, &errs);
-			file.close();
-
-			if (parsingSuccessful)
+			std::ifstream file(filepath, std::ifstream::binary);
+			if (file.is_open())
 			{
-				ipAddress = root.get("ip", "").asString();
-				port = root.get("port", "").asString();
-				playerName = root.get("name", "").asString();
+				Json::Value root;
+				Json::CharReaderBuilder builder;
+				std::string errs;
 
-				
-				if (ipAddress.empty())
+				bool parsingSuccessful = Json::parseFromStream(builder, file, &root, &errs);
+				file.close();
+
+				if (parsingSuccessful)
 				{
-					// ip is empty
-					ipAddress = "127.0.0.1";
+					ipAddress = root.get("ip", "").asString();
+					port = root.get("port", "").asString();
 				}
-
-				if (port == "")
-				{
-					// port is empty
-					port = "61008";
-				}
-
-
-				if (playerName == "")
-				{
-					// name is empty
-					playerName = "Jane Kelly";
-				}
-
-				_ipAddress->setText(ipAddress);
-				_port->setText(port);
-				_playerName->setText(playerName);
-				_game->getCoopMod()->setHostName(playerName); 
 			}
-			else
-			{
-				std::cerr << "Failed to parse JSON: " << errs << std::endl;
-			}
-		}
-		else
-		{
-			std::cerr << "Failed to open the file." << std::endl;
 		}
 	}
+
+	if (ipAddress.empty())
+		ipAddress = "127.0.0.1";
+	if (port.empty())
+		port = "61008";
+
+	_ipAddress->setText(ipAddress);
+	_port->setText(port);
 
 }
 
@@ -287,8 +238,6 @@ void DirectConnect::init()
 		_ipAddress->setVisible(false);
 		_lblPort->setVisible(false);
 		_port->setVisible(false);
-		_lblPlayerName->setVisible(false);
-		_playerName->setVisible(false);
 		_tcpButtonJoin->setVisible(false);
 		_txtInfo->setVisible(false);
 
@@ -301,8 +250,6 @@ void DirectConnect::init()
 		_ipAddress->setVisible(true);
 		_lblPort->setVisible(true);
 		_port->setVisible(true);
-		_lblPlayerName->setVisible(true);
-		_playerName->setVisible(true);
 		_tcpButtonJoin->setVisible(true);
 		_txtInfo->setVisible(false);
 
@@ -480,11 +427,6 @@ bool DirectConnect::parseUdpPort(const std::string& text, uint16_t& outPort)
 	return true;
 }
 
-void DirectConnect::edtPlayerNameChange(Action* action)
-{
-	_game->getCoopMod()->setHostName(_playerName->getText());
-}
-
 void DirectConnect::cbxNetworkProtocolChange(Action* action)
 {
 
@@ -505,6 +447,23 @@ void DirectConnect::cbxNetworkProtocolChange(Action* action)
 
 void DirectConnect::joinTCPGame(Action* action)
 {
+
+	// Save client settings to JSON
+	{
+		std::string filepath = Options::getMasterUserFolder() + "client_address.json";
+		Json::Value root;
+		root["ip"] = _ipAddress->getText();
+		root["port"] = _port->getText();
+
+		std::ofstream file(filepath);
+		if (file.is_open())
+		{
+			Json::StreamWriterBuilder writer;
+			writer["indentation"] = "\t";
+			file << Json::writeString(writer, root);
+			file.close();
+		}
+	}
 
 	// JOIN GAME
 	_game->getCoopMod()->setCoopSession(false);

--- a/src/CoopMod/DirectConnect.h
+++ b/src/CoopMod/DirectConnect.h
@@ -90,7 +90,7 @@ class DirectConnect : public State
 	TextButton *_btnCancel, *_tcpButtonJoin;
 	TextEdit *_ipAddress, *_playerName, *_port;
 	Window *_window;
-	Text *_txtTitle, *_txtData, *_txtInfo;
+	Text *_txtTitle, *_txtData, *_txtInfo, *_lblHostIp, *_lblPort, *_lblPlayerName;
 	std::map<Surface *, bool> _surfaceBackup;
 	Craft *_craft;
 	NewBattleSelectType _selectType;

--- a/src/CoopMod/DirectConnect.h
+++ b/src/CoopMod/DirectConnect.h
@@ -88,9 +88,9 @@ class DirectConnect : public State
 {
   private:
 	TextButton *_btnCancel, *_tcpButtonJoin;
-	TextEdit *_ipAddress, *_playerName, *_port;
+	TextEdit *_ipAddress, *_port;
 	Window *_window;
-	Text *_txtTitle, *_txtData, *_txtInfo, *_lblHostIp, *_lblPort, *_lblPlayerName;
+	Text *_txtTitle, *_txtData, *_txtInfo, *_lblHostIp, *_lblPort;
 	std::map<Surface *, bool> _surfaceBackup;
 	Craft *_craft;
 	NewBattleSelectType _selectType;
@@ -111,8 +111,6 @@ class DirectConnect : public State
 	void init() override;
 	void btnCancelClick(Action *action);
 	void joinTCPGame(Action *action);
-	/// Handler for changing the text on the Name edit.
-	void edtPlayerNameChange(Action* action);
 	void cbxNetworkProtocolChange(Action* action);
 };
 

--- a/src/CoopMod/HostMenu.cpp
+++ b/src/CoopMod/HostMenu.cpp
@@ -271,15 +271,15 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 
 	}
 
-	// READ IP ADDRESS
+	// READ HOST ADDRESS
 
 	// Name of the JSON file
-	std::string filename = "ip_address.json";
+	std::string filename = "host_address.json";
 	std::string filepath = Options::getMasterUserFolder() + filename;
 
-	std::string ipAddress;
 	std::string port;
 	std::string serverName;
+	std::string password;
 
 	if (OpenXcom::CrossPlatform::fileExists(filepath))
 	{
@@ -295,17 +295,11 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 
 			if (parsingSuccessful)
 			{
-				ipAddress = root.get("ip", "").asString();
 				port = root.get("port", "").asString();
 				serverName = root.get("server", "").asString();
+				password = root.get("password", "").asString();
 
 				
-				if (ipAddress.empty())
-				{
-					// ip is empty
-					ipAddress = "IP-ADDRESS";
-				}
-
 				if (port == "")
 				{
 					// port is empty
@@ -320,7 +314,11 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 				}
 
 				_port->setText(port);
-				_serverName->setText(serverName); 
+				_serverName->setText(serverName);
+				if (password != "")
+				{
+					_password->setText(password);
+				}
 			}
 			else
 			{
@@ -656,6 +654,24 @@ void HostMenu::cbxRegionChange(Action*)
 
 void HostMenu::hostTCPGame(Action* action)
 {
+
+	// Save host settings to JSON
+	{
+		std::string filepath = Options::getMasterUserFolder() + "host_address.json";
+		Json::Value root;
+		root["server"] = _serverName->getText();
+		root["port"] = _port->getText();
+		root["password"] = _password->getText();
+
+		std::ofstream file(filepath);
+		if (file.is_open())
+		{
+			Json::StreamWriterBuilder writer;
+			writer["indentation"] = "\t";
+			file << Json::writeString(writer, root);
+			file.close();
+		}
+	}
 
 	connectionTCP::password = "";
 	connectionTCP::isPasswordRequired = false;

--- a/src/CoopMod/HostMenu.cpp
+++ b/src/CoopMod/HostMenu.cpp
@@ -50,20 +50,24 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	int x = 20;
 	
 	// Create objects
-	_window = new Window(this, 216, 160, x, 20, POPUP_BOTH);
-	_lstSaves = new TextList(180, 18, x + 18, 60);
+	_window = new Window(this, 260, 160, x, 20, POPUP_BOTH);
+	_lstSaves = new TextList(224, 18, x + 18, 60);
 
-	_port = new TextEdit(this, 180, 18, x + 18, 92);
-	_serverName = new TextEdit(this, 180, 18, x + 18, 72);
-	_tcpButtonHost = new TextButton(90, 18, x + 18, 152);
-	_btnStartHotseat = new TextButton(180, 18, x + 18, 112);
-	_btnReactionFire = new TextButton(180, 18, x + 18, 132);
-	_cbxVisibility = new ComboBox(this, 180, 18, x + 18, 50);
-	_cbxRegions = new ComboBox(this, 90, 18, x + 18, 112); 
-	_cbxMaxPlayers = new ComboBox(this, 90, 18, x + 108, 112); 
-	_password = new TextEdit(this, 180, 18, x + 18, 132);
-	_btnCancel = new TextButton(90, 18, x + 108, 152);
-	_txtTitle = new Text(206, 17, x + 5, 32);
+	_lblServerName = new Text(108, 18, x + 18, 72);
+	_lblPort = new Text(108, 18, x + 18, 92);
+	_lblPassword = new Text(108, 18, x + 18, 132);
+
+	_port = new TextEdit(this, 116, 18, x + 126, 92);
+	_serverName = new TextEdit(this, 116, 18, x + 126, 72);
+	_tcpButtonHost = new TextButton(112, 18, x + 18, 152);
+	_btnStartHotseat = new TextButton(224, 18, x + 18, 112);
+	_btnReactionFire = new TextButton(224, 18, x + 18, 132);
+	_cbxVisibility = new ComboBox(this, 224, 18, x + 18, 50);
+	_cbxRegions = new ComboBox(this, 112, 18, x + 18, 112); 
+	_cbxMaxPlayers = new ComboBox(this, 112, 18, x + 130, 112); 
+	_password = new TextEdit(this, 116, 18, x + 126, 132);
+	_btnCancel = new TextButton(112, 18, x + 130, 152);
+	_txtTitle = new Text(250, 17, x + 5, 32);
 
 	int screenWidth = Options::baseXGeoscape;
 	int screenHeight = Options::baseYGeoscape;
@@ -74,9 +78,12 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 
 
 	add(_window, "window", "pauseMenu");
-	add(_port);
-	add(_serverName);
-	add(_password);
+	add(_lblServerName, "text", "pauseMenu");
+	add(_lblPort, "text", "pauseMenu");
+	add(_lblPassword, "text", "pauseMenu");
+	add(_port, "text", "pauseMenu");
+	add(_serverName, "text", "pauseMenu");
+	add(_password, "text", "pauseMenu");
 	add(_tcpButtonHost, "button", "pauseMenu");
 	add(_btnStartHotseat, "button", "pauseMenu");
 	add(_btnReactionFire, "button", "pauseMenu");
@@ -108,17 +115,36 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	_txtTitle->setBig();
 	_txtTitle->setText(tr("HOST"));
 
+	// labels
+	_lblServerName->setBig();
+	_lblServerName->setBorderColor(color);
+	_lblServerName->setText("GAME NAME>");
+	_lblServerName->setVisible(false);
+
+	_lblPort->setBig();
+	_lblPort->setBorderColor(color);
+	_lblPort->setText("PORT>");
+	_lblPort->setVisible(false);
+
+	_lblPassword->setBig();
+	_lblPassword->setBorderColor(color);
+	_lblPassword->setText("PASSWORD>");
+	_lblPassword->setVisible(false);
+
 	// port
 	_port->setColor(color);
 	_port->setBig();
 	_port->setBorderColor(color);
-	_port->setText("PORT");
+	_port->setConstraint(TEC_NUMERIC_POSITIVE);
+	_port->setAllowOverflow(true);
+	_port->setText("61008");
 	_port->setVisible(false);
 
 	_serverName->setColor(color);
 	_serverName->setBig();
 	_serverName->setBorderColor(color);
-	_serverName->setText("Server");
+	_serverName->setAllowOverflow(true);
+	_serverName->setText("Vigilo Confido");
 	_serverName->setVisible(false);
 	
 	_tcpButtonHost->setText("START HOST");
@@ -177,7 +203,9 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	_password->setColor(color);
 	_password->setBig();
 	_password->setBorderColor(color);
-	_password->setText("Password");
+	_password->setAllowOverflow(true);
+	_password->setBorderColor(color);
+	_password->setText("");
 	_password->setVisible(false);
 
 	// check if campaign mission
@@ -198,9 +226,12 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 		// hide
 		_tcpButtonHost->setVisible(false);
 		_port->setVisible(false);
+		_lblPort->setVisible(false);
 		_serverName->setVisible(false);
+		_lblServerName->setVisible(false);
 		_cbxVisibility->setVisible(false);
 		_password->setVisible(false);
+		_lblPassword->setVisible(false);
 		_cbxMaxPlayers->setVisible(false);
 		_cbxRegions->setVisible(false);
 		_btnReactionFire->setVisible(false);
@@ -214,10 +245,13 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	{
 
 		_port->setVisible(false);
+		_lblPort->setVisible(false);
 		_serverName->setVisible(false);
+		_lblServerName->setVisible(false);
 		_tcpButtonHost->setVisible(false);
 		_cbxVisibility->setVisible(false);
 		_password->setVisible(false);
+		_lblPassword->setVisible(false);
 		_cbxMaxPlayers->setVisible(false);
 		_cbxRegions->setVisible(false);
 
@@ -225,10 +259,13 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	else if (_game->getCoopMod()->isConnected() == -1)
 	{
 		_port->setVisible(true);
+		_lblPort->setVisible(true);
 		_serverName->setVisible(true);
+		_lblServerName->setVisible(true);
 		_tcpButtonHost->setVisible(true);
 		_cbxVisibility->setVisible(true);
 		_password->setVisible(true);
+		_lblPassword->setVisible(true);
 		_cbxMaxPlayers->setVisible(true);
 		_cbxRegions->setVisible(true);
 
@@ -279,7 +316,7 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 				if (serverName == "")
 				{
 					// name is empty
-					serverName = "Server";
+					serverName = "Vigilo Confido";
 				}
 
 				_port->setText(port);
@@ -319,9 +356,12 @@ void HostMenu::init()
 		// hide
 		_tcpButtonHost->setVisible(false);
 		_port->setVisible(false);
+		_lblPort->setVisible(false);
 		_serverName->setVisible(false);
+		_lblServerName->setVisible(false);
 		_cbxVisibility->setVisible(false);
 		_password->setVisible(false);
+		_lblPassword->setVisible(false);
 		_cbxMaxPlayers->setVisible(false);
 		_cbxRegions->setVisible(false);
 
@@ -344,10 +384,13 @@ void HostMenu::init()
 	{
 
 		_port->setVisible(false);
+		_lblPort->setVisible(false);
 		_serverName->setVisible(false);
+		_lblServerName->setVisible(false);
 		_tcpButtonHost->setVisible(false);
 		_cbxVisibility->setVisible(false);
 		_password->setVisible(false);
+		_lblPassword->setVisible(false);
 		_cbxMaxPlayers->setVisible(false);
 		_cbxRegions->setVisible(false);
 
@@ -355,10 +398,13 @@ void HostMenu::init()
 	else if (_game->getCoopMod()->isConnected() == -1)
 	{
 		_port->setVisible(true);
+		_lblPort->setVisible(true);
 		_serverName->setVisible(true);
+		_lblServerName->setVisible(true);
 		_tcpButtonHost->setVisible(true);
 		_cbxVisibility->setVisible(true);
 		_password->setVisible(true);
+		_lblPassword->setVisible(true);
 		_cbxMaxPlayers->setVisible(true);
 		_cbxRegions->setVisible(true);
 
@@ -537,8 +583,11 @@ void HostMenu::cbxVisibilityChange(Action* action)
 	// show
 	_tcpButtonHost->setVisible(true);
 	_port->setVisible(true);
+	_lblPort->setVisible(true);
 	_serverName->setVisible(true);
+	_lblServerName->setVisible(true);
 	_password->setVisible(true);
+	_lblPassword->setVisible(true);
 	_cbxMaxPlayers->setVisible(true);
 	_cbxRegions->setVisible(true);
 
@@ -553,8 +602,11 @@ void HostMenu::cbxVisibilityChange(Action* action)
 		// hide
 		_tcpButtonHost->setVisible(false);
 		_port->setVisible(false);
+		_lblPort->setVisible(false);
 		_serverName->setVisible(false);
+		_lblServerName->setVisible(false);
 		_password->setVisible(false);
+		_lblPassword->setVisible(false);
 		_cbxMaxPlayers->setVisible(false);
 		_cbxRegions->setVisible(false);
 
@@ -609,7 +661,7 @@ void HostMenu::hostTCPGame(Action* action)
 	connectionTCP::isPasswordRequired = false;
 
 	// password
-	if (_password->getText() != "" && _password->getText() != "Password")
+	if (_password->getText() != "")
 	{
 
 		connectionTCP::password = _password->getText();
@@ -622,10 +674,13 @@ void HostMenu::hostTCPGame(Action* action)
 	_game->getCoopMod()->setCoopSession(false);
 
 	_port->setVisible(false);
+	_lblPort->setVisible(false);
 	_serverName->setVisible(false);
+	_lblServerName->setVisible(false);
 	_tcpButtonHost->setVisible(false);
 	_cbxVisibility->setVisible(false);
 	_password->setVisible(false);
+	_lblPassword->setVisible(false);
 	_cbxMaxPlayers->setVisible(false);
 	_cbxRegions->setVisible(false);
 
@@ -679,7 +734,7 @@ void HostMenu::hostTCPGame(Action* action)
 		std::string udpPassword = "";
 
 		// password
-		if (_password->getText() != "" && _password->getText() != "Password")
+		if (_password->getText() != "")
 		{
 			udpPassword = _password->getText();
 		}
@@ -740,10 +795,13 @@ void HostMenu::startHotseat(Action* action)
 
 	// hide
 	_port->setVisible(false);
+	_lblPort->setVisible(false);
 	_tcpButtonHost->setVisible(false);
 	_serverName->setVisible(false);
+	_lblServerName->setVisible(false);
 	_cbxVisibility->setVisible(false);
 	_password->setVisible(false);
+	_lblPassword->setVisible(false);
 	_cbxMaxPlayers->setVisible(false);
 	_cbxRegions->setVisible(false);
 

--- a/src/CoopMod/HostMenu.h
+++ b/src/CoopMod/HostMenu.h
@@ -86,7 +86,7 @@ class HostMenu : public State
 	TextEdit *_serverName, *_port, *_password;
 	ComboBox *_cbxVisibility, *_cbxMaxPlayers, *_cbxRegions;
 	Window *_window;
-	Text *_txtTitle;
+	Text *_txtTitle, *_lblServerName, *_lblPort, *_lblPassword;
 	std::map<Surface *, bool> _surfaceBackup;
 	std::vector<std::string> _visibilityTypes, _maxplayersTypes, _regionTypes;
 	Craft *_craft;

--- a/src/CoopMod/LobbyMenu.cpp
+++ b/src/CoopMod/LobbyMenu.cpp
@@ -250,7 +250,7 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 	}
 
 	_txtDetails->setWordWrap(true);
-	_txtDetails->setText(tr("STR_DETAILS").arg(""));
+	_txtDetails->setText(tr("STR_DETAILS").arg("Waiting for players on port " + std::to_string(tcp_port)));
 
 	_sortName->setX(_sortName->getX() + _txtName->getTextWidth() + 5);
 	_sortName->onMouseClick((ActionHandler)&LobbyMenu::sortNameClick);
@@ -526,6 +526,8 @@ void LobbyMenu::lstSavesMouseOver(Action*)
 	{
 		wstr = _connectedPlayers[sel].details;
 	}
+	if (wstr.empty())
+		wstr = "Waiting for players on port " + std::to_string(tcp_port);
 	_txtDetails->setText(tr("STR_DETAILS").arg(wstr));
 }
 
@@ -535,7 +537,7 @@ void LobbyMenu::lstSavesMouseOver(Action*)
  */
 void LobbyMenu::lstSavesMouseOut(Action*)
 {
-	_txtDetails->setText(tr("STR_DETAILS").arg(""));
+	_txtDetails->setText(tr("STR_DETAILS").arg("Waiting for players on port " + std::to_string(tcp_port)));
 }
 
 /**

--- a/src/CoopMod/LobbyMenu.cpp
+++ b/src/CoopMod/LobbyMenu.cpp
@@ -147,7 +147,6 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 	_txtTeam = new Text(110, 9, 204, isMobile ? 40 : 32);
 	_txtLatency = new Text(110, 9, 263, isMobile ? 40 : 32);
 	_lstPlayers = new TextList(288, isMobile ? 104 : 112, 8, isMobile ? 50 : 42);
-	_playername = new TextEdit(this, 100, 16, 16, 140);
 	_txtDetails = new Text(288, 16, 16, 156);
 	_sortName = new ArrowButton(ARROW_NONE, 11, 8, 16, isMobile ? 40 : 32);
 	_sortTeam = new ArrowButton(ARROW_NONE, 11, 8, 204, isMobile ? 40 : 32);
@@ -166,7 +165,6 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 	add(_txtTeam, "text", "saveMenus");
 	add(_txtLatency, "text", "saveMenus");
 	add(_lstPlayers, "list", "saveMenus");
-	add(_playername);
 	add(_txtDetails, "text", "saveMenus");
 	add(_sortName, "text", "saveMenus");
 	add(_sortTeam, "text", "saveMenus");
@@ -249,20 +247,6 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 		{
 			color = 255;
 		}
-	}
-
-	_playername->setColor(color);
-	_playername->setBorderColor(color);
-	_playername->setText(_game->getCoopMod()->getHostName());
-	_playername->onChange((ActionHandler)&LobbyMenu::edtPlayerNameChange);
-
-	if (connectionTCP::isCoopSessionLocked == true)
-	{
-		_playername->setVisible(false);
-	}
-	else
-	{
-		_playername->setVisible(true);
 	}
 
 	_txtDetails->setWordWrap(true);
@@ -694,15 +678,6 @@ void LobbyMenu::think()
 
 		lastUpdate = now;
 
-		if (connectionTCP::isCoopSessionLocked == true)
-		{
-			_playername->setVisible(false);
-		}
-		else
-		{
-			_playername->setVisible(true);
-		}
-
 		// own player
 		std::string txtTeam = "XCOM";
 		const int hostId = 1;
@@ -956,71 +931,6 @@ void LobbyMenu::sortTeamClick(Action* action)
 		_lstPlayers->clearList();
 		sortList(Options::playerOrder);
 	}
-}
-
-void LobbyMenu::savePlayerNameToIpAddressFile(std::string playerName)
-{
-	std::string filename = Options::getMasterUserFolder() + "/ip_address.json";
-
-	Json::Value root;
-
-	// Read existing file first so other fields are preserved
-	{
-		std::ifstream inputFile(filename);
-
-		if (!inputFile.is_open())
-		{
-			std::cerr << "Failed to open ip_address.json for reading." << std::endl;
-			return;
-		}
-
-		Json::CharReaderBuilder reader;
-		JSONCPP_STRING errors;
-
-		if (!Json::parseFromStream(reader, inputFile, &root, &errors))
-		{
-			std::cerr << "Failed to parse ip_address.json: " << errors << std::endl;
-			return;
-		}
-	}
-
-	// Only update the player name
-	root["name"] = playerName;
-
-	// Write the same JSON back to file
-	std::ofstream outputFile(filename, std::ios::out | std::ios::trunc);
-
-	if (!outputFile.is_open())
-	{
-		std::cerr << "Failed to open ip_address.json for writing." << std::endl;
-		return;
-	}
-
-	Json::StreamWriterBuilder writer;
-	writer["indentation"] = "\t";
-
-	outputFile << Json::writeString(writer, root);
-
-	std::cout << "Player name saved to ip_address.json." << std::endl;
-}
-
-void LobbyMenu::edtPlayerNameChange(Action* action)
-{
-	_game->getCoopMod()->setHostName(_playername->getText());
-
-	savePlayerNameToIpAddressFile(_game->getCoopMod()->getHostName());
-
-	if (_game->getCoopMod()->getCoopStatic() == true)
-	{
-
-		Json::Value root;
-		root["state"] = "change_player_name";
-		root["name"] = _game->getCoopMod()->getHostName();
-
-		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
-
-	}
-
 }
 
 }

--- a/src/CoopMod/LobbyMenu.h
+++ b/src/CoopMod/LobbyMenu.h
@@ -45,7 +45,6 @@ protected:
 	Window *_window;
 	Text *_txtTitle, *_txtName, *_txtLatency, *_txtDetails, *_txtTeam, *_txtChangeTeam;
 	TextList *_lstPlayers;
-	TextEdit *_playername;
 	ArrowButton *_sortName, *_sortLatency, *_sortTeam;
 	OptionsOrigin _origin;
 	std::vector<playerInfo> _connectedPlayers;
@@ -54,7 +53,6 @@ protected:
 	bool _timerStarted = false;
 	int _countdown = 30; // seconds
 	void updateArrows();
-	void savePlayerNameToIpAddressFile(std::string playerName);
   public:
 	/// Creates the Game state.
 	LobbyMenu();
@@ -84,7 +82,6 @@ protected:
 	void sortNameClick(Action* action);
 	void sortLatencyClick(Action* action);
 	void sortTeamClick(Action* action);
-	void edtPlayerNameChange(Action* action);
 
 };
 

--- a/src/CoopMod/Profile.cpp
+++ b/src/CoopMod/Profile.cpp
@@ -60,7 +60,7 @@ Profile::Profile()
 	}
 	else
 	{
-		result = "You have joined the " + playerName + "'s game";
+		result = "You have joined " + playerName + "'s game";
 	}
 
 	_txtName->setText(result);

--- a/src/CoopMod/ServerList.cpp
+++ b/src/CoopMod/ServerList.cpp
@@ -158,7 +158,8 @@ ServerList::ServerList() : _sortable(true)
 
 	int x = 8;
 
-	_playername = new TextEdit(this, 100, h, x, y - 34);
+	_playername = new TextEdit(this, 140, h, x + 65, y - 34);
+	_lblPlayerName = new Text(65, h, x, y - 34);
 	_search = new TextEdit(this, 100, h, x + 55, y - 18);
 	_btnFilter = new TextButton(wHost, h, x, y - 18);
 	_btnHost = new TextButton(wHost, h, x, y);
@@ -190,6 +191,7 @@ ServerList::ServerList() : _sortable(true)
 	setInterface("geoscape", true, _game->getSavedGame() ? _game->getSavedGame()->getSavedBattle() : 0);
 
 	add(_window, "window", "saveMenus");
+	add(_lblPlayerName, "text", "saveMenus");
 	add(_playername);
 	add(_search);
 	add(_btnFilter, "button", "saveMenus");
@@ -230,9 +232,41 @@ ServerList::ServerList() : _sortable(true)
 	_search->onMouseClick((ActionHandler)&ServerList::btnSearchClick);
 	_search->onChange((ActionHandler)&ServerList::edtSearchChange);
 
-	_playername->setColor(color);
-	_playername->setBorderColor(color);
-	_playername->setText(_game->getCoopMod()->getHostName());
+	_lblPlayerName->setColor(color);
+	_lblPlayerName->setBorderColor(color);
+	_lblPlayerName->setText("PLAYER NAME>");
+	_lblPlayerName->setVisible(true);
+
+	_playername->setColor(500);
+	_playername->setBorderColor(500);
+
+	// Read saved player name
+	{
+		std::string filepath = Options::getMasterUserFolder() + "player_name.json";
+		std::string savedName;
+
+		if (OpenXcom::CrossPlatform::fileExists(filepath))
+		{
+			std::ifstream file(filepath, std::ifstream::binary);
+			if (file.is_open())
+			{
+				Json::Value root;
+				Json::CharReaderBuilder builder;
+				std::string errs;
+
+				if (Json::parseFromStream(builder, file, &root, &errs))
+				{
+					savedName = root.get("name", "").asString();
+				}
+			}
+		}
+
+		if (savedName.empty())
+			savedName = "Jane Kelly";
+
+		_game->getCoopMod()->setHostName(savedName);
+		_playername->setText(savedName);
+	}
 	_playername->setVisible(true);
 	_playername->onChange((ActionHandler)&ServerList::edtPlayerNameChange);
 
@@ -648,48 +682,19 @@ bool ServerList::removeManuallyAddedServerFromFile()
 
 void ServerList::savePlayerNameToIpAddressFile(std::string playerName)
 {
-	std::string filename = Options::getMasterUserFolder() + "/ip_address.json";
+	std::string filepath = Options::getMasterUserFolder() + "player_name.json";
 
 	Json::Value root;
-
-	// Read existing file first so other fields are preserved
-	{
-		std::ifstream inputFile(filename);
-
-		if (!inputFile.is_open())
-		{
-			std::cerr << "Failed to open ip_address.json for reading." << std::endl;
-			return;
-		}
-
-		Json::CharReaderBuilder reader;
-		JSONCPP_STRING errors;
-
-		if (!Json::parseFromStream(reader, inputFile, &root, &errors))
-		{
-			std::cerr << "Failed to parse ip_address.json: " << errors << std::endl;
-			return;
-		}
-	}
-
-	// Only update the player name
 	root["name"] = playerName;
 
-	// Write the same JSON back to file
-	std::ofstream outputFile(filename, std::ios::out | std::ios::trunc);
-
-	if (!outputFile.is_open())
+	std::ofstream file(filepath);
+	if (file.is_open())
 	{
-		std::cerr << "Failed to open ip_address.json for writing." << std::endl;
-		return;
+		Json::StreamWriterBuilder writer;
+		writer["indentation"] = "\t";
+		file << Json::writeString(writer, root);
+		file.close();
 	}
-
-	Json::StreamWriterBuilder writer;
-	writer["indentation"] = "\t";
-
-	outputFile << Json::writeString(writer, root);
-
-	std::cout << "Player name saved to ip_address.json." << std::endl;
 }
 
 bool ServerList::isAllowedBySearch(std::string serverName)

--- a/src/CoopMod/ServerList.h
+++ b/src/CoopMod/ServerList.h
@@ -43,6 +43,7 @@ class ServerList : public State
 protected:
 	TextButton *_btnHost, *_btnDirectConnect, *_btnAddServer, *_btnRefresh, *_btnCancel, *_btnFilter;
 	TextEdit *_search, *_playername;
+	Text *_lblPlayerName;
 	Window *_window;
 	Text *_txtTitle, *_txtName, *_txtPlayers, *_txtRegion, *_txtJoin, *_txtPasswordRequired;
 	TextList *_lstServers;

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -1759,7 +1759,7 @@ void connectionTCP::initProfile(bool clientInBattle, bool inBattle)
 				connectionTCP::LobbyFileStatus = 1;
 			}
 		}
-		// CHECK IF THE HOST IS IN BATTLE — IF SO, ADD JOINERS; OTHERWISE DO NOTHING
+		// CHECK IF THE HOST IS IN BATTLE ï¿½ IF SO, ADD JOINERS; OTHERWISE DO NOTHING
 		else if (inBattle == true)
 		{
 
@@ -5644,6 +5644,8 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		long long saveID = obj["saveID"].asInt64();
 		connectionTCP::saveID = saveID;
 
+		tcpPlayerName = obj.get("playername", tcpPlayerName).asString();
+
 		_game->pushState(new Profile);
 
 	}
@@ -5683,6 +5685,8 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		connectionTCP::forceCloseCoopStateMenu = true;
 		connectionTCP::forceClosePasswordCheckMenu = true;
 
+		tcpPlayerName = obj.get("playername", tcpPlayerName).asString();
+
 		_game->pushState(new Profile);
 
 		Json::Value root;
@@ -5703,31 +5707,6 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 			j_markers = "";
 
 			_battleInit = false;
-
-			// Define the file path and values to write
-			std::string filename = Options::getMasterUserFolder() + "/ip_address.json";
-
-			// Create JSON object
-			Json::Value root133;
-			root133["ip"] = ipAddress;
-			root133["port"] = tcp_port;
-			root133["name"] = sendTcpPlayer;
-			root133["server"] = sendTcpServerName;
-
-			// Write JSON to file
-			std::ofstream file(filename);
-			if (file.is_open())
-			{
-				Json::StreamWriterBuilder writer;
-				file << Json::writeString(writer, root133);
-				file.close();
-
-				std::cout << "IP address and player name written to " << filename << std::endl;
-			}
-			else
-			{
-				std::cerr << "Failed to open file for writing." << std::endl;
-			}
 
 			// RESET ALL SOLDIERS OUT OF THE BASES
 			for (auto* base : *_game->getSavedGame()->getBases())
@@ -5810,6 +5789,9 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		{
 			root["state"] = "COOP_READY_CLIENT_REQUEST_PROFILE";
 		}
+
+		root["playername"] = sendTcpPlayer;
+		root["servername"] = sendTcpServerName;
 
 		sendTCPPacketData(root.toStyledString());
 
@@ -5970,31 +5952,6 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		// bases
 		int64_t base_count = obj["base_count"].asInt64();
 		playersBases = base_count;
-
-		// Define the file path and values to write
-		std::string filename = Options::getMasterUserFolder() + "/ip_address.json";
-
-		// Create JSON object
-		Json::Value root135;
-		root135["ip"] = ipAddress;
-		root135["port"] = tcp_port;
-		root135["name"] = sendTcpPlayer;
-		root135["server"] = sendTcpServerName;
-
-		// Write JSON to file
-		std::ofstream file(filename);
-		if (file.is_open())
-		{
-			Json::StreamWriterBuilder writer;
-			file << Json::writeString(writer, root135);
-			file.close();
-
-			std::cout << "IP address and player name written to " << filename << std::endl;
-		}
-		else
-		{
-			std::cerr << "Failed to open file for writing." << std::endl;
-		}
 
 		// campaign check
 		bool host_coop_campaign = obj["coop_campaign"].asBool();

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -135,6 +135,7 @@ namespace OpenXcom
 // Definitions must exist exactly once in a .cpp file, normally connectionTCP.cpp:
 extern SPSCQueue<1024> g_txQ;
 extern SPSCQueue<1024> g_rxQ;
+extern int tcp_port;
 
 // Existing name kept for compatibility: this only enqueues to g_txQ.
 // It does not have to mean that the active transport is TCP.

--- a/src/Interface/TextEdit.cpp
+++ b/src/Interface/TextEdit.cpp
@@ -36,7 +36,7 @@ namespace OpenXcom
  * @param y Y position in pixels.
  */
 TextEdit::TextEdit(State *state, int width, int height, int x, int y) : InteractiveSurface(width, height, x, y),
-	_blink(true), _modal(true), _drawBackground(true),
+	_blink(true), _modal(true), _allowOverflow(false), _drawBackground(true),
 	_char('A'), _caretPos(0), _textEditConstraint(TEC_NONE),
 	_change(0), _enter(0), _state(state)
 {
@@ -497,7 +497,7 @@ void TextEdit::keyboardPress(Action *action, State *state)
 			}
 			break;
 		case SDLK_RIGHT:
-			if (!exceedsMaxWidth(_char))
+			if (_allowOverflow || !exceedsMaxWidth(_char))
 			{
 				_value += _char;
 			}
@@ -558,7 +558,7 @@ void TextEdit::keyboardPress(Action *action, State *state)
 			break;
 		default:
 			UCode c = action->getDetails()->key.keysym.unicode;
-			if (isValidChar(c) && !exceedsMaxWidth(c))
+			if (isValidChar(c) && (_allowOverflow || !exceedsMaxWidth(c)))
 			{
 				_value.insert(_caretPos, 1, c);
 				_caretPos++;

--- a/src/Interface/TextEdit.h
+++ b/src/Interface/TextEdit.h
@@ -37,7 +37,7 @@ class TextEdit : public InteractiveSurface
 private:
 	Text *_text, *_caret;
 	UString _value;
-	bool _blink, _modal;
+	bool _blink, _modal, _allowOverflow;
 	bool _drawBackground;
 	Timer *_timer;
 	UCode _char;
@@ -107,6 +107,8 @@ public:
 	void onEnter(ActionHandler handler);
 	/// Sets the text edit's background drawing setting.
 	void setDrawBackground(bool drawBackground) { _drawBackground = drawBackground; }
+	/// Allow text to overflow the widget width instead of blocking input.
+	void setAllowOverflow(bool allow) { _allowOverflow = allow; }
 };
 
 }


### PR DESCRIPTION
## Summary

Resolves #18 

Redesigns the Host Game and Direct Connect dialogs with descriptive text labels, sensible defaults, and clear separation of configuration files. Consolidates the player name to a single authoritative source (the Server Browser).

### Host Menu

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/be1fdefe-9c10-45ca-851a-cc63521e49c5" />

- Adds left-aligned arrow labels: `GAME NAME>`, `PORT>`, `PASSWORD>`
- Window widened 20% (216px to 260px) to fit label + input layout
- Defaults: `Vigilo Confido`, `61008`, empty password
- Port field constrained to digits only (`TEC_NUMERIC_POSITIVE`)
- Writes to `host_address.json` only when START HOST is clicked
- Reads from `host_address.json` on dialog open, falls back to hardcoded defaults if no file

### Direct Connect

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/f2fb70b7-3c4d-4670-8cd8-4847a12cc092" />

- Adds left-aligned arrow labels: `HOST IP>`, `PORT>`
- Window widened 20% (216px to 260px)
- Defaults: `127.0.0.1`, `61008`
- Port field constrained to digits only
- Player name field removed (delegated to Server Browser)
- Writes to `client_address.json` only when JOIN is clicked
- Reads from `client_address.json` on dialog open, with proper fallback defaults

### Server Browser

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/d6bda16b-6297-4004-b323-aca87a8625f9" />

- Added `PLAYER NAME>` label to the left of the player name field
- Now the **single authoritative source** for the player's name
- On load: reads `player_name.json`, falls back to `"Jane Kelly"` if no file
- On change: saves to `player_name.json` immediately
- CoopMenu and LobbyMenu now read the name from `getHostName()` (no hardcoded defaults, no JSON reads)
- CoopMenu and LobbyMenu now no longer have a TextEdit allowing players to change their name. Multiple write points were leading to a lot of bugged states around player names default/cached values

### Lobby

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/ba3a850e-21cc-4518-938d-9f7b6437db68" />

Added port details for reference when the player is not hovering over a player to see player details.

### Configuration file split

| File | Keys | Written by | Read by |
|---|---|---|---|
| `host_address.json` | `server`, `port`, `password` | HostMenu (START HOST) | HostMenu |
| `client_address.json` | `ip`, `port` | DirectConnect (JOIN) | DirectConnect, CoopMenu |
| `player_name.json` | `name` | Server Browser | Server Browser, CoopMenu |

All JSON writes removed from `connectionTCP.cpp` — the handshake no longer silently overwrites configuration files. Files are only written on explicit user actions (button clicks).

### Framework changes

- **`TextEdit::setAllowOverflow(bool)`** — when enabled, text can exceed the widget width (clips visually) instead of blocking keystrokes. HostMenu and DirectConnect TextEdits use this.
- **`loadBuiltInKeysOrWarn()`** — variant of `loadBuiltInKeysOrFail()` that doesn't escalate a missing rendezvous config into a fatal "Server error" dialog. Instead shows a non-fatal notice while keeping the Server Browser open for Direct Connect / Host.

### Bug fixes

- Fixed Profile dialog showing `"You have joined Player's game"` when the host's name wasn't included in the `COOP_READY_SAVE_PROGRESS` packet
- Fixed fallback defaults not applying when `client_address.json` doesn't exist (DirectConnect, CoopMenu)
- Fixed `"You have joined the ...'s game"` → `"You have joined ...'s game"` tyop

### Files changed

- `src/CoopMod/HostMenu.h`, `src/CoopMod/HostMenu.cpp`
- `src/CoopMod/DirectConnect.h`, `src/CoopMod/DirectConnect.cpp`
- `src/CoopMod/ServerList.h`, `src/CoopMod/ServerList.cpp`
- `src/CoopMod/LobbyMenu.h`, `src/CoopMod/LobbyMenu.cpp`
- `src/CoopMod/CoopMenu.cpp`