### PR TITLE
fix(coop): conflation slot for geoscape sync + MPMC-safe packet queues

### DIFF
--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -247,6 +247,77 @@ SPSCQueue<1024> g_rxQ{};
 static std::mutex g_rxHoldMutex;
 static std::deque<std::string> g_rxHold;
 
+// ===== Geoscape sync conflation slot =====
+// One overwrite slot per snapshot channel (see CoopSnapSlot). The main thread
+// (GeoscapeState::think) overwrites; the send drain reads the freshest value and
+// clears the dirty flag. Written/read under g_snapMx so a mid-read frame can't be
+// torn by a concurrent overwrite.
+static std::mutex g_snapMx;
+static std::array<std::string, SNAP_COUNT> g_snap;
+static std::array<bool, SNAP_COUNT> g_snapDirty{}; // value-init -> all false
+
+void enqueueSnapshot(CoopSnapSlot slot, std::string&& s)
+{
+	if (slot < 0 || slot >= SNAP_COUNT)
+		return;
+	std::lock_guard<std::mutex> lk(g_snapMx);
+	g_snap[slot] = std::move(s); // discards only the stale prior snapshot (LWW-safe)
+	g_snapDirty[slot] = true;
+}
+
+bool anySnapshotDirty()
+{
+	std::lock_guard<std::mutex> lk(g_snapMx);
+	for (int i = 0; i < SNAP_COUNT; ++i)
+		if (g_snapDirty[i])
+			return true;
+	return false;
+}
+
+bool popSnapshot(std::string& out)
+{
+	std::lock_guard<std::mutex> lk(g_snapMx);
+	for (int i = 0; i < SNAP_COUNT; ++i)
+	{
+		if (g_snapDirty[i])
+		{
+			out = g_snap[i]; // raw payload; UDP sends whole messages (no framing)
+			g_snapDirty[i] = false;
+			return true;
+		}
+	}
+	return false;
+}
+
+static inline void appendFramed(std::string& out, const std::string& payload); // defined below
+
+// Append every dirty snapshot into `out` (framed) and clear its flag. Called by
+// the send drains right after the g_txQ batch, so snapshots ride the same
+// sendAll as the reliable batch (freshest value only, at link rate).
+static void drainSnapshotsInto(std::string& out)
+{
+	std::lock_guard<std::mutex> lk(g_snapMx);
+	for (int i = 0; i < SNAP_COUNT; ++i)
+	{
+		if (g_snapDirty[i])
+		{
+			appendFramed(out, g_snap[i]);
+			g_snapDirty[i] = false;
+		}
+	}
+}
+
+// Reset conflation slots on session teardown (mirrors the g_rxHold clear).
+static void clearSnapshotSlots()
+{
+	std::lock_guard<std::mutex> lk(g_snapMx);
+	for (int i = 0; i < SNAP_COUNT; ++i)
+	{
+		g_snap[i].clear();
+		g_snapDirty[i] = false;
+	}
+}
+
 // ===== Time helper =====
 static inline uint64_t now_ms()
 {
@@ -299,6 +370,8 @@ void clearNetworkSessionQueues()
 		std::lock_guard<std::mutex> lock(g_rxHoldMutex);
 		g_rxHold.clear();
 	}
+
+	clearSnapshotSlots();
 }
 
 // HOST: emit PING once per second (independent from client)
@@ -1393,6 +1466,9 @@ void connectionTCP::startTCPClient()
 				appendFramed(out, msg);
 				++batched;
 			}
+			// Conflated geoscape snapshots ride the same framed write as the
+			// reliable batch (freshest value only, at link rate -> no backlog).
+			drainSnapshotsInto(out);
 			if (!out.empty())
 			{
 				if (!sendAll(sock, out.data(), (int)out.size()))
@@ -1507,7 +1583,7 @@ void connectionTCP::startTCPClient()
 		clientMaybeSendPing();
 
 		// ---- Gentle yield only if nothing happened ----
-		if (ready == 0 && g_txQ.empty())
+		if (ready == 0 && g_txQ.empty() && !anySnapshotDirty())
 		{
 #ifdef _WIN32
 			SDL_Delay(0);
@@ -1617,6 +1693,9 @@ void connectionTCP::startTCPHost()
 				appendFramed(out, msg);
 				++batched;
 			}
+			// Conflated geoscape snapshots ride the same framed write as the
+			// reliable batch (freshest value only, at link rate -> no backlog).
+			drainSnapshotsInto(out);
 			if (!out.empty())
 			{
 				if (!sendAll(clientSock, out.data(), (int)out.size()))
@@ -1717,7 +1796,7 @@ void connectionTCP::startTCPHost()
 			hostMaybeSendPing();
 
 		// ---- Gentle yield if nothing to do ----
-		if (ready == 0 && OpenXcom::g_txQ.empty())
+		if (ready == 0 && OpenXcom::g_txQ.empty() && !OpenXcom::anySnapshotDirty())
 		{
 #ifdef _WIN32
 			SDL_Delay(0);
@@ -7905,6 +7984,16 @@ void connectionTCP::sendTCPPacketData(std::string data)
 	{
 		DebugLog("TX queue full, dropping packet\n");
 	}
+}
+
+void connectionTCP::sendCoopSnapshot(int slot, std::string data)
+{
+	if (data.empty())
+		return;
+	// Full-state last-write-wins snapshot -> conflation slot, not the FIFO. The
+	// send drain emits the freshest value at link rate; stale copies are elided,
+	// so the geoscape flood can never overflow g_txQ.
+	enqueueSnapshot(static_cast<CoopSnapSlot>(slot), std::move(data));
 }
 
 void connectionTCP::setPlayerTurn(int turn)

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -86,45 +86,52 @@ inline void DebugLog(const char* msg)
 	DebugLog(std::string(msg));
 }
 
+// Bounded ring buffer of std::string slots. NOTE: despite the name, this is NOT
+// single-producer/single-consumer in this codebase. g_txQ/g_rxQ each have 3+
+// producers and 2+ consumers (main thread, network thread, loopData thread, UDP
+// thread, plus clearNetworkSessionQueues). Concurrent buf[] std::string moves on
+// the same slot double-free the heap (the crash mis-symbolized as SDL_FreeRW). So
+// every operation is serialized by an internal mutex that covers the buf[] move,
+// not just the cursor. The name is kept to avoid churn at ~40 call sites.
 template <size_t N>
 struct SPSCQueue
 {
 	std::array<std::string, N> buf{};
-	std::atomic<size_t> head{0}; // producer writes
-	std::atomic<size_t> tail{0}; // consumer reads
+	size_t head{0}; // producer writes (guarded by m)
+	size_t tail{0}; // consumer reads  (guarded by m)
+	mutable std::mutex m;
 
 	bool push(std::string&& s)
 	{
-		size_t h = head.load(std::memory_order_relaxed);
-		size_t n = (h + 1) % N;
-		if (n == tail.load(std::memory_order_acquire))
+		std::lock_guard<std::mutex> lk(m);
+		size_t n = (head + 1) % N;
+		if (n == tail)
 			return false; // full
-		buf[h] = std::move(s);
-		head.store(n, std::memory_order_release);
+		buf[head] = std::move(s);
+		head = n;
 		return true;
 	}
 
 	bool pop(std::string& out)
 	{
-		size_t t = tail.load(std::memory_order_relaxed);
-		if (t == head.load(std::memory_order_acquire))
+		std::lock_guard<std::mutex> lk(m);
+		if (tail == head)
 			return false; // empty
-		out = std::move(buf[t]);
-		tail.store((t + 1) % N, std::memory_order_release);
+		out = std::move(buf[tail]);
+		tail = (tail + 1) % N;
 		return true;
 	}
 
 	bool empty() const
 	{
-		return tail.load(std::memory_order_acquire) ==
-			   head.load(std::memory_order_acquire);
+		std::lock_guard<std::mutex> lk(m);
+		return tail == head;
 	}
 
 	bool full() const
 	{
-		size_t h = head.load(std::memory_order_relaxed);
-		size_t n = (h + 1) % N;
-		return n == tail.load(std::memory_order_acquire);
+		std::lock_guard<std::mutex> lk(m);
+		return ((head + 1) % N) == tail;
 	}
 };
 
@@ -136,6 +143,25 @@ namespace OpenXcom
 extern SPSCQueue<1024> g_txQ;
 extern SPSCQueue<1024> g_rxQ;
 extern int tcp_port;
+
+// ===== Geoscape sync conflation slot =====
+// The two GeoscapeState::think() heartbeats are full-state, last-write-wins
+// snapshots. Instead of FIFO-queuing every per-frame copy onto g_txQ (which
+// overflows on a slow link), each channel keeps a single overwrite slot; the
+// send thread emits the freshest one at whatever rate the link drains. Preserves
+// update rate (no throttle) while eliminating the backlog.
+enum CoopSnapSlot { SNAP_GEO_POSITIONS = 0, SNAP_GEO_TIME = 1, SNAP_COUNT };
+
+// Overwrite the conflation slot with the newest snapshot (thread-safe).
+void enqueueSnapshot(CoopSnapSlot slot, std::string&& s);
+
+// True if any conflation slot has an unsent snapshot (send thread wake check).
+bool anySnapshotDirty();
+
+// Pop one dirty conflation slot as a raw (unframed) payload, clearing its dirty
+// flag; returns false if none pending. Used by the UDP transport, whose datagram
+// path sends whole messages (the TCP path uses drainSnapshotsInto, which frames).
+bool popSnapshot(std::string& out);
 
 // Existing name kept for compatibility: this only enqueues to g_txQ.
 // It does not have to mean that the active transport is TCP.
@@ -219,6 +245,9 @@ class connectionTCP
 	void loadHostMap();
 	static bool getCoopStatic(); // is the player actually connected?
 	void sendTCPPacketData(std::string data); // Send TCP packet data
+	// Send a full-state geoscape snapshot via the conflation slot (last-write-wins,
+	// never queued FIFO). slot is a CoopSnapSlot. Used by GeoscapeState::think().
+	void sendCoopSnapshot(int slot, std::string data);
 	static bool getHost();
 	static int getHostSpaceAvailable();
 	static void setHostSpaceAvailable(int _hostSpace);

--- a/src/CoopMod/connectionUDP/connection_udp_glue.cpp
+++ b/src/CoopMod/connectionUDP/connection_udp_glue.cpp
@@ -272,10 +272,15 @@ bool startUdpPeer(const std::string& remoteHost,
 	cfg.enablePortGuessing = true;
 	cfg.portGuessRadius = 32;
 
-	// TX: read exactly the same queue that TCP used.
+	// TX: read exactly the same queue that TCP used, then the geoscape conflation
+	// slots (the two full-state think() heartbeats bypass g_txQ; without this the
+	// "time"/"target_positions" snapshots never go out over UDP, freezing the
+	// host clock — see connectionTCP drainSnapshotsInto for the TCP counterpart).
 	cfg.popTx = [](std::string& out) -> bool
 	{
-		return g_txQ.pop(out);
+		if (g_txQ.pop(out))
+			return true;
+		return popSnapshot(out);
 	};
 
 	// RX: write exactly the same queue that connectionTCP::updateCoopTask()

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1620,8 +1620,9 @@ void GeoscapeState::think()
 
 			}
 
-			// send
-			_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+			// send — full-state positional snapshot via the conflation slot
+			// (last-write-wins; never FIFO-queued, so it can't overflow g_txQ).
+			_game->getCoopMod()->sendCoopSnapshot(SNAP_GEO_POSITIONS, root.toStyledString());
 
 		}
 
@@ -1689,7 +1690,8 @@ void GeoscapeState::think()
 		bool inDogfight = _minimizedDogfights < _dogfights.size();
 		root["geo_focus"] = inDogfight ? 0 : -1;
 
-		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+		// time/focus heartbeat via the conflation slot (last-write-wins).
+		_game->getCoopMod()->sendCoopSnapshot(SNAP_GEO_TIME, root.toStyledString());
 	}
 
 	// coop: refresh the ally time-speed markers on the speed buttons.


### PR DESCRIPTION
Fixes the reported "TX queue full, dropping packet" / ~19,000 ms ping bug on a constrained/relayed link, without reducing the geoscape update rate, and closes the heap-corruption crash that symbolized as SDL_FreeRW.

Root cause: GeoscapeState::think() serializes the whole geoscape to JSON and pushes it onto the shared 1024-slot FIFO g_txQ every main-loop iteration (not FPS-gated). When the single blocking send thread drains slower than that push rate (slow link / VPN relay), the FIFO fills with stale, superseded snapshots and enqueueTx silently drops packets before TCP ever sees them; PING/PONG and file-transfer acks then queue behind the backlog (the ~19k ping and the "stuck at Requesting map data" hang). Latent for everyone; only surfaces when link drain < loop-rate push, so it never reproduces on LAN/localhost.

Conflation slot: the two think() heartbeats (target_positions, time) are full-state, last-write-wins snapshots, so every queued copy but the newest is waste. Route them through connectionTCP::sendCoopSnapshot -> a single overwrite slot per channel (enqueueSnapshot / g_snap / g_snapMx) instead of g_txQ. The send paths emit the freshest slot at whatever rate the link drains:
  - TCP: drainSnapshotsInto() appends the framed snapshot to the same batch write (connectionTCP send loops).
  - UDP: popSnapshot() yields the raw payload after g_txQ in the popTx lambda (connection_udp_glue.cpp), so the datagram transport sends it too. Update rate is preserved (no throttle / no fixed-latency floor); fast links keep near-loop-rate fidelity, slow links coalesce naturally with no backlog or drops. All other coop packets stay on the reliable FIFO.

Thread-safety: g_txQ/g_rxQ are declared SPSCQueue but actually have 3+ producers and 2+ consumers (main, network, loopData and UDP threads, plus clearNetworkSessionQueues). Concurrent buf[] std::string moves double-freed the heap. Guard every push/pop/empty with an internal mutex covering the move; both queues become MPMC-safe with no call-site changes.

Verified with a deterministic 2-client repro under an emulated slow link: 0 drops sustained where the pre-fix build dropped tens of thousands within ~1s, snapshots still flowing and peer time in lockstep; UDP host-clock freeze (peer "time" heartbeat never sent over the datagram path) resolved and confirmed by a player.