### PR TITLE
feat(coop): host-authoritative saves, campaign lobby redesign, and hardening

### DIFF
--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1771,7 +1771,7 @@ void BattlescapeState::think()
 				}
 		
 				// PVP
-				// This only runs in PvP mode. The XCOM player’s time units are reset here. The alien player’s time units are reset elsewhere, after the XCOM player’s turn has ended
+				// This only runs in PvP mode. The XCOM playerï¿½s time units are reset here. The alien playerï¿½s time units are reset elsewhere, after the XCOM playerï¿½s turn has ended
 				/*
 				if ((_game->getCoopMod()->getCoopGamemode() == 2 || _game->getCoopMod()->getCoopGamemode() == 3) && _game->getCoopMod()->_isActivePlayerSync == true)
 				{
@@ -5302,7 +5302,12 @@ inline void BattlescapeState::handle(Action *action)
 					}
 					else if (key == Options::keyQuickLoad)
 					{
-						_game->pushState(new LoadGameState(OPT_BATTLESCAPE, SAVE_QUICK, _palette));
+						// coop: no local load during a live session (host mid-battle
+						// load would fork the served world - C7/PRD-08).
+						if (_game->getCoopMod()->localLoadsAllowed())
+						{
+							_game->pushState(new LoadGameState(OPT_BATTLESCAPE, SAVE_QUICK, _palette));
+						}
 					}
 				}
 

--- a/src/Battlescape/NextTurnState.cpp
+++ b/src/Battlescape/NextTurnState.cpp
@@ -615,15 +615,8 @@ void NextTurnState::close()
 
 			}
 
-			// Auto save after (only HOST)
 			if (_game->getCoopMod()->getCoopStatic() == true && _game->getCoopMod()->getHost() == true)
 			{
-
-				SavedGame* newsave = new SavedGame(*_game->getSavedGame());
-
-				newsave->setName("coop_mission");
-
-				newsave->save("coop_mission.sav", _game->getMod());
 
 				if (_battleGame->getTurn() >= 1)
 				{

--- a/src/CoopMod/CoopState.cpp
+++ b/src/CoopMod/CoopState.cpp
@@ -65,9 +65,32 @@ CoopState::CoopState(int state)
 
 	int x = 20;
 
-	_window = new Window(this, 216, 160, x, 20, POPUP_BOTH);
-
-	_txtTitle = new Text(206, 17, x + 5, 100);
+	if (state == COOP_DLG_CLIENT_HOLD || state == COOP_DLG_CLIENT_RESUME_HOLD)
+	{
+		// compact variant: a third of the standard height, vertically
+		// centered, with room for two small wrapped lines (no button)
+		_window = new Window(this, 216, 54, x, 73, POPUP_BOTH);
+		_txtTitle = new Text(206, 26, x + 5, 88);
+	}
+	else if (state == COOP_DLG_WAIT_BASES)
+	{
+		// same compact styling as the client's hold dialog (they show the same
+		// "waiting for bases" message), but with room for the BEGIN button
+		_window = new Window(this, 216, 68, x, 66, POPUP_BOTH);
+		_txtTitle = new Text(206, 26, x + 5, 72);
+	}
+	else if (state == COOP_DLG_FREEZE)
+	{
+		// ~30% of the old height: a small "waiting for X to reconnect" strip
+		// with room for the RESUME button that appears once the peer is back
+		_window = new Window(this, 216, 52, x, 74, POPUP_BOTH);
+		_txtTitle = new Text(206, 22, x + 5, 78);
+	}
+	else
+	{
+		_window = new Window(this, 216, 160, x, 20, POPUP_BOTH);
+		_txtTitle = new Text(206, 17, x + 5, 100);
+	}
 	_btnMessage = new TextButton(100, 17, x + 55, 100);
 	_btnBack = new TextButton(100, 17, x + 55, 150);
 	_btnYes = new TextButton(80, 20, 40, 150);
@@ -116,7 +139,7 @@ CoopState::CoopState(int state)
 	_btnYes->onKeyboardPress((ActionHandler)&CoopState::btnYesClick, Options::keyOk);
 
 	// HostLoadProgress (client)
-	if (state == 52)
+	if (state == COOP_DLG_CLIENT_LOAD_WAIT)
 	{
 		_game->getCoopMod()->load_state = "Loading";
 
@@ -124,6 +147,10 @@ CoopState::CoopState(int state)
 
 		_btnBack->setText("Disconnect");
 		_btnBack->setVisible(true);
+
+		// PRD-11 C13: fresh load-wait dialog, clear any stale busy signal so the
+		// first host reply drives the retry state machine cleanly.
+		connectionTCP::loadProgressBusy = false;
 	}
 
 	// Player was kicked
@@ -169,8 +196,106 @@ CoopState::CoopState(int state)
 		_btnBack->setVisible(true);
 	}
 
-	// HostSaveProgress (host)
-	if (state == 54)
+	// refused by a join gate (roster / duplicate name, flow-redesign F3)
+	if (state == 63)
+	{
+		_txtTitle->setSmall();
+		_txtTitle->setText(connectionTCP::joinRefusalReason.empty()
+							   ? "You are not a player in this campaign."
+							   : connectionTCP::joinRefusalReason);
+
+		_btnBack->setText(tr("OK"));
+		_btnBack->setVisible(true);
+	}
+
+	// host waits for resuming players to finish loading (flow-redesign F3)
+	if (state == COOP_DLG_RESUME_ACK_WAIT)
+	{
+		_txtTitle->setText("Waiting for players to load...");
+
+		_btnBack->setText("RESUME");
+		_btnBack->setVisible(false);
+	}
+
+	// mid-session freeze: a registered player dropped; everything waits
+	// until they reconnect and reload (flow-redesign F4/D5)
+	if (state == COOP_DLG_FREEZE)
+	{
+		_txtTitle->setSmall();
+		_txtTitle->setWordWrap(true);
+		_txtTitle->setText("Waiting for " + _game->getCoopMod()->getCurrentClientName() + " to reconnect...");
+
+		_btnBack->setText("RESUME");
+		_btnBack->setY(104);
+		_btnBack->setVisible(false);
+	}
+
+	// non-host player finished early (base placed / world loaded) and holds
+	// with frozen time until the host resumes the campaign (D5)
+	if (state == COOP_DLG_CLIENT_HOLD || state == COOP_DLG_CLIENT_RESUME_HOLD)
+	{
+		_txtTitle->setSmall();
+		_txtTitle->setWordWrap(true);
+		// fresh new-campaign base building vs. a mid-session rejoin: same hold,
+		// different reason. The rejoining client's bases already exist - it is
+		// only waiting for the host to un-freeze the session.
+		if (state == COOP_DLG_CLIENT_RESUME_HOLD)
+		{
+			_txtTitle->setText("Waiting for host to resume the game.");
+		}
+		else
+		{
+			_txtTitle->setText("Waiting for all players\nto place their bases...");
+		}
+
+		_btnBack->setVisible(false);
+
+		// consume any stale release from a previous hold
+		connectionTCP::session.consumeCampaignBegun();
+	}
+
+	// the host identity is locked to the save (D4)
+	if (state == 66)
+	{
+		std::string owner = "its creator";
+		if (_game->getSavedGame() && !_game->getSavedGame()->getCoopPlayers().empty())
+		{
+			owner = _game->getSavedGame()->getCoopPlayers()[0];
+		}
+		_txtTitle->setSmall();
+		_txtTitle->setText("This campaign can only be hosted by " + owner + ".");
+
+		_btnBack->setText(tr("OK"));
+		_btnBack->setVisible(true);
+	}
+
+	// solo campaigns can never be hosted as co-op (flow-redesign D1)
+	if (state == 61)
+	{
+		_txtTitle->setSmall();
+		_txtTitle->setText("This is a solo campaign. Co-op campaigns are created from the New Game menu.");
+
+		_btnBack->setText(tr("OK"));
+		_btnBack->setVisible(true);
+	}
+
+	// new-campaign base building: host waits until every player has placed
+	// a base; the button turns into RESUME when they have (flow-redesign F2)
+	if (state == COOP_DLG_WAIT_BASES)
+	{
+		// same wording + compact styling as the client's hold dialog
+		// (COOP_DLG_CLIENT_HOLD) - one message, one look, two actors
+		_txtTitle->setSmall();
+		_txtTitle->setWordWrap(true);
+		_txtTitle->setText("Waiting for all players\nto place their bases...");
+
+		_btnBack->setText("BEGIN");
+		_btnBack->setY(108);
+		_btnBack->setVisible(false);
+	}
+
+	// host-save cycle (host)
+	if (state == COOP_DLG_HOST_SAVE_WAIT)
 	{
 		
 		_game->getCoopMod()->load_state = "Saving";
@@ -186,7 +311,7 @@ CoopState::CoopState(int state)
 
 	}
 
-	// HostSaveProgress (client)
+	// host-save cycle (client)
 	if (state == 53)
 	{
 		_game->getCoopMod()->load_state = "Saving";
@@ -608,6 +733,26 @@ CoopState::~CoopState()
 {
 }
 
+std::string CoopState::getTitleText() const
+{
+	return _txtTitle ? _txtTitle->getText() : "";
+}
+
+std::string CoopState::getBackText() const
+{
+	return _btnBack ? _btnBack->getText() : "";
+}
+
+bool CoopState::isBackVisible() const
+{
+	return _btnBack && _btnBack->getVisible();
+}
+
+int CoopState::getWindowHeight() const
+{
+	return _window ? _window->getHeight() : 0;
+}
+
 void CoopState::think()
 {
 
@@ -620,6 +765,38 @@ void CoopState::think()
 	{
 
 		lastUpdate = now;
+
+		// PRD-11 C13: bounded retry when the host replies "busy" to the client's
+		// request_load_progress. Without this the load-wait dialog (52) hangs
+		// forever (no timeout). On the busy signal, wait ~2s then re-send; after
+		// a bounded number of retries, fall back to the disconnect error UX.
+		if (global_state == COOP_DLG_CLIENT_LOAD_WAIT)
+		{
+			const int kMaxLoadRetries = 15;
+			if (connectionTCP::loadProgressBusy)
+			{
+				connectionTCP::loadProgressBusy = false;
+				_loadWaitTicks = 4; // ~2s at the 500ms gate before retrying
+			}
+			if (_loadWaitTicks > 0 && --_loadWaitTicks == 0)
+			{
+				if (_loadRetries < kMaxLoadRetries)
+				{
+					_loadRetries++;
+					Json::Value root;
+					root["state"] = "request_load_progress";
+					_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+					Log(LOG_INFO) << "[coop] load progress retry " << _loadRetries << "/" << kMaxLoadRetries;
+				}
+				else
+				{
+					_txtTitle->setSmall();
+					_txtTitle->setText("Host is busy; could not load progress.");
+					_btnBack->setText("Disconnect");
+					_btnBack->setVisible(true);
+				}
+			}
+		}
 
 		// Force-close the co-op state menu
 		if (connectionTCP::forceCloseCoopStateMenu == true && global_state == 15)
@@ -649,7 +826,7 @@ void CoopState::think()
 			}
 
 		}
-		else if (global_state == 4 || global_state == 54 || global_state == 53 || global_state == 52)
+		else if (global_state == 4 || global_state == COOP_DLG_HOST_SAVE_WAIT || global_state == 53 || global_state == COOP_DLG_CLIENT_LOAD_WAIT)
 		{
 
 			if (state_counter == 0)
@@ -666,6 +843,44 @@ void CoopState::think()
 			{
 				_txtTitle->setText(_game->getCoopMod()->load_state + "...");
 				state_counter = 0;
+			}
+
+		}
+		else if (global_state == COOP_DLG_WAIT_BASES)
+		{
+
+			// all players placed = every registered client's world blob has
+			// arrived (a client pushes progress right after base naming)
+			bool allPlaced = connectionTCP::hasCoopFile(
+				connectionTCP::hostBlobKey(_game->getCoopMod()->getCurrentClientName()));
+
+			if (allPlaced)
+			{
+				_txtTitle->setText("All bases placed.");
+				_btnBack->setText("BEGIN");
+				_btnBack->setVisible(true);
+			}
+
+		}
+		else if (global_state == COOP_DLG_RESUME_ACK_WAIT || global_state == COOP_DLG_FREEZE)
+		{
+
+			// resuming/rejoining players report in via resume_ack (F3/F4)
+			if (connectionTCP::session.resumeAck)
+			{
+				_txtTitle->setText("All players connected");
+				_btnBack->setVisible(true);
+			}
+
+		}
+		else if (global_state == COOP_DLG_CLIENT_HOLD || global_state == COOP_DLG_CLIENT_RESUME_HOLD)
+		{
+
+			// released when the host begins/resumes the campaign
+			if (connectionTCP::session.campaignBegun)
+			{
+				connectionTCP::session.consumeCampaignBegun();
+				_game->popState();
 			}
 
 		}
@@ -728,8 +943,22 @@ void CoopState::think()
 void CoopState::previous(Action *)
 {
 
+	// The host clicked RESUME on a waiting dialog: release every non-host
+	// player from their "waiting for players" hold (D5).
+	if (global_state == COOP_DLG_WAIT_BASES || global_state == COOP_DLG_RESUME_ACK_WAIT || global_state == COOP_DLG_FREEZE)
+	{
+		connectionTCP::session.sessionLive();
+
+		Json::Value root;
+		root["state"] = "campaign_begun";
+		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+	}
+
 	// disconnect
-	if (global_state == 50 || global_state == 1 || global_state == 88 || global_state == 3 || global_state == 4 || global_state == 15 || global_state == 53)
+	// PRD-11 C13: COOP_DLG_CLIENT_LOAD_WAIT (52) added - its "Disconnect" button
+	// must actually tear the connection down, not merely pop the dialog and leave
+	// the client half-attached.
+	if (global_state == 50 || global_state == 1 || global_state == 88 || global_state == 3 || global_state == 4 || global_state == 15 || global_state == 53 || global_state == COOP_DLG_CLIENT_LOAD_WAIT)
 	{
 
 		if (global_state == 15)
@@ -746,6 +975,15 @@ void CoopState::previous(Action *)
 	{
 
 		_game->setState(new MainMenuState);
+	}
+	// PRD-06 C5: CANCEL on the host "saving..." wait dialog. The user asked for
+	// a save - honour it NOW with whatever client blob is currently in the store
+	// (same staleness guarantee autosaves already have), then disarm so a late
+	// client blob can't rewrite a possibly-different world.
+	else if (global_state == COOP_DLG_HOST_SAVE_WAIT)
+	{
+		_game->getCoopMod()->writePendingHostSave();
+		_game->popState();
 	}
 	else
 	{
@@ -824,12 +1062,13 @@ void CoopState::loadWorld()
 
 		client_save->loadCoopSaveFromMemory(filename, _game->getMod(), _game->getLanguage(), filename);
 
-		if (client_save && connectionTCP::_host_save_progress == true && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
+		if (client_save && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
 		{
 
-			std::string filename = "host_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getCurrentClientName() + ".data";
+			std::string filename = connectionTCP::hostBlobKey(_game->getCoopMod()->getCurrentClientName());
 
-			client_save->save(filename, _game->getMod());
+			// served copy lives in memory only; the host .sav embed persists it
+			client_save->saveCoopToMemory(filename, _game->getMod(), filename);
 
 		}
 
@@ -998,7 +1237,7 @@ void CoopState::loadWorld()
 	}
 	else if (global_state == 555)
 	{
-		std::string filename = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+		std::string filename = connectionTCP::clientBlobKey(_game->getCoopMod()->getHostName());
 		_game->pushState(new LoadGameState(OPT_GEOSCAPE, filename, _palette, filename, true));
 	}
 	else if (global_state == 777)
@@ -1180,11 +1419,6 @@ void CoopState::loadWorld()
 		}
 		else
 		{
-
-			// save the co-op mission so it can be continued later
-			SavedGame *oldsave = new SavedGame(*_game->getSavedGame());
-			oldsave->setName("coop_mission");
-			oldsave->save("coop_mission.sav", _game->getMod());
 
 			// load battle
 			_game->pushState(new LoadGameState(_origin, "battleclient", _palette, "battleclient"));

--- a/src/CoopMod/CoopState.h
+++ b/src/CoopMod/CoopState.h
@@ -31,6 +31,26 @@ class Text;
 class GeoscapeState;
 
 /**
+ * Named dialog codes for CoopState. CoopState is a multi-purpose wait/prompt
+ * dialog selected by a raw int passed to its constructor. Explicit values so
+ * nothing renumbers (the ints appear in logs and harness tests).
+ *
+ * Only the codes that participate in the campaign-wait lifecycle (and the two
+ * save/load wait dialogs) are named here so far; the remaining placeholder
+ * codes scattered through the coop states are still raw literals pending a
+ * future documentation pass (out of scope for PRD-01).
+ */
+enum CoopDialogCode {
+	COOP_DLG_CLIENT_LOAD_WAIT = 52, // client "loading" wait
+	COOP_DLG_HOST_SAVE_WAIT   = 54, // host "saving" wait
+	COOP_DLG_WAIT_BASES       = 60, // host waits for every client to place a base
+	COOP_DLG_RESUME_ACK_WAIT  = 62, // host waits for resuming players to ack
+	COOP_DLG_FREEZE           = 64, // mid-session freeze: a player dropped
+	COOP_DLG_CLIENT_HOLD      = 65, // client placed base, holds until host resumes
+	COOP_DLG_CLIENT_RESUME_HOLD = 68, // rejoined client holds until host resumes
+};
+
+/**
  * Options window shown for loading/saving/quitting the game.
  * Not to be confused with the Game Options window
  * for changing game settings during runtime.
@@ -44,6 +64,11 @@ class CoopState : public State
 	TextButton *_btnMessage, *_btnBack, *_btnYes;
 	int global_state = 0;
 	int state_counter = 0;
+	// PRD-11 C13: retry bookkeeping for the client load-wait dialog (52). When
+	// the host replies "busy", wait ~2s (_loadWaitTicks at the 500ms gate) then
+	// re-send request_load_progress, up to a bounded number of retries.
+	int _loadRetries = 0;
+	int _loadWaitTicks = 0;
   public:
 	/// Creates the Pause state.
 	CoopState(int state);
@@ -55,6 +80,24 @@ class CoopState : public State
 	void loadWorld();
 	void setGlobe(Globe *globe);
 	void setBaseName(std::string name);
+	/// Which dialog this is (see the state-code blocks in the constructor).
+	int getStateCode() const { return global_state; }
+	/// Introspection for the test harness: the current title / back-button text
+	/// and whether the back button is visible.
+	std::string getTitleText() const;
+	std::string getBackText() const;
+	bool isBackVisible() const;
+	int getWindowHeight() const;
+	/// True for the campaign-wait family (60/62/64/65/67): dialogs that manage
+	/// their own lifetime and must never be popped by save/load-progress handlers.
+	bool isCampaignWaitDialog() const
+	{
+		return global_state == COOP_DLG_WAIT_BASES
+			|| global_state == COOP_DLG_RESUME_ACK_WAIT
+			|| global_state == COOP_DLG_FREEZE
+			|| global_state == COOP_DLG_CLIENT_HOLD
+			|| global_state == COOP_DLG_CLIENT_RESUME_HOLD;
+	}
 	/// Runs the timers and handles popups.
 	void think() override;
 };

--- a/src/CoopMod/HostMenu.cpp
+++ b/src/CoopMod/HostMenu.cpp
@@ -21,6 +21,7 @@
 #include "HostMenu.h"
 #include "../Menu/SaveGameState.h"
 #include "../Menu/LoadGameState.h"
+#include "../Menu/MainMenuState.h"
 #include "CoopState.h"
 #include "../Mod/ExtraSprites.h"
 #include "../Engine/Surface.h"
@@ -249,7 +250,11 @@ HostMenu::HostMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 		_btnStartHotseat->setText("DISABLE HOTSEAT");
 
 	}
-	else if ((_game->getCoopMod()->isConnected() == 1) || _game->getCoopMod()->getServerOwner() == true)
+	// Hide the hosting controls only while a session is genuinely live (a
+	// peer is attached). Keying on isConnected()/getServerOwner() left stale
+	// transport state (esp. after UDP host/disconnect cycles) blanking the
+	// whole window down to the CANCEL button.
+	else if (_game->getCoopMod()->getCoopStatic() == true && _game->getCoopMod()->isCoopSession() == true)
 	{
 
 		_port->setVisible(false);
@@ -389,7 +394,11 @@ void HostMenu::init()
 		_btnStartHotseat->setText("DISABLE HOTSEAT");
 
 	}
-	else if ((_game->getCoopMod()->isConnected() == 1) || _game->getCoopMod()->getServerOwner() == true)
+	// Hide the hosting controls only while a session is genuinely live (a
+	// peer is attached). Keying on isConnected()/getServerOwner() left stale
+	// transport state (esp. after UDP host/disconnect cycles) blanking the
+	// whole window down to the CANCEL button.
+	else if (_game->getCoopMod()->getCoopStatic() == true && _game->getCoopMod()->isCoopSession() == true)
 	{
 
 		_port->setVisible(false);
@@ -668,6 +677,35 @@ void HostMenu::cbxRegionChange(Action*)
 void HostMenu::hostTCPGame(Action* action)
 {
 
+	// Solo campaigns can never be hosted as co-op (flow-redesign D1):
+	// co-op campaigns are created from the New Game menu or resumed from a
+	// co-op save. One-off battles (no countries) are unaffected.
+	if (_game->getSavedGame()
+		&& !_game->getSavedGame()->getCountries()->empty()
+		&& !_game->getSavedGame()->isCoopSave())
+	{
+		_game->pushState(new CoopState(61));
+		return;
+	}
+
+	// the host identity is locked to the save (D4): a different local player
+	// name may never host this campaign
+	if (_game->getCoopMod()->inCoopCampaignContext()
+		&& !_game->getSavedGame()->getCoopPlayers().empty()
+		&& _game->getSavedGame()->getCoopPlayers()[0] != _game->getCoopMod()->getHostName())
+	{
+		_game->pushState(new CoopState(66));
+		return;
+	}
+
+	// campaign co-op save: (re)derive the lobby mode from the save so a
+	// disconnect + re-host cannot fall back to the legacy READY lobby - a
+	// fresh world (no locked players) starts, an established one resumes
+	if (_game->getCoopMod()->inCoopCampaignContext())
+	{
+		connectionTCP::session.lobbyMode = _game->getSavedGame()->getCoopPlayers().empty() ? 1 : 2;
+	}
+
 	// Save host settings to JSON
 	{
 		std::string filepath = Options::getMasterUserFolder() + "host_address.json";
@@ -702,16 +740,9 @@ void HostMenu::hostTCPGame(Action* action)
 
 	_game->getCoopMod()->setCoopSession(false);
 
-	_port->setVisible(false);
-	_lblPort->setVisible(false);
-	_serverName->setVisible(false);
-	_lblServerName->setVisible(false);
-	_tcpButtonHost->setVisible(false);
-	_cbxVisibility->setVisible(false);
-	_password->setVisible(false);
-	_lblPassword->setVisible(false);
-	_cbxMaxPlayers->setVisible(false);
-	_cbxRegions->setVisible(false);
+	// (no field-hiding here: this menu is popped right below, and hiding the
+	// controls first could strand a blank window with just CANCEL whenever a
+	// path re-surfaced the instance - the UDP host/disconnect-cycle bug)
 
 	_game->getCoopMod()->setPlayerTurn(3);
 
@@ -740,7 +771,7 @@ void HostMenu::hostTCPGame(Action* action)
 
 	}
 
-	if (_game->getCoopMod()->getCoopCampaign() == true && connectionTCP::_host_save_progress == true)
+	if (_game->getCoopMod()->getCoopCampaign() == true)
 	{
 		convert = false;
 	}
@@ -804,7 +835,7 @@ void HostMenu::hostTCPGame(Action* action)
 	_game->getCoopMod()->setServerOwner(true);
 
 	// If the player has created a server or joined another player's game, close the ServerList and create the LobbyMenu
-	if (Options::HostSaveProgress == true && _game->getCoopMod()->getCoopCampaign() == true)
+	if (_game->getCoopMod()->getCoopCampaign() == true)
 	{
 		_game->popState();
 
@@ -815,6 +846,22 @@ void HostMenu::hostTCPGame(Action* action)
 		_game->popState();
 	}
 
+}
+
+void HostMenu::testHostWithVisibility(int comboIndex)
+{
+	_cbxVisibility->setSelected(comboIndex);
+	cbxVisibilityChange(nullptr);
+	hostTCPGame(nullptr);
+}
+
+bool HostMenu::hostControlsVisible() const
+{
+	// the window counts as usable if the primary action (START HOST or the
+	// hotseat toggle) or the connection-type combo can be interacted with
+	return _tcpButtonHost->getVisible()
+		|| _btnStartHotseat->getVisible()
+		|| _cbxVisibility->getVisible();
 }
 
 void HostMenu::startHotseat(Action* action)
@@ -880,6 +927,16 @@ void HostMenu::btnReactionFireClick(Action* action)
  */
 void HostMenu::btnCancelClick(Action*)
 {
+	// campaign flow: leaving the host window abandons the (paused, not yet
+	// running) co-op session - back to the main menu, never into the world
+	// without the other players (D5). Derived from the SAVE, not lobbyMode:
+	// the disconnect cleanup can reset lobbyMode (disconnect -> cancel path).
+	if (_game->getCoopMod()->inCoopCampaignContext())
+	{
+		_game->setState(new GoToMainMenuState(false));
+		return;
+	}
+
 	_game->popState();
 }
 

--- a/src/CoopMod/HostMenu.h
+++ b/src/CoopMod/HostMenu.h
@@ -113,6 +113,9 @@ class HostMenu : public State
 	void cbxVisibilityChange(Action* action);
 	void cbxMaxPlayersChange(Action* action);
 	void cbxRegionChange(Action* action);
+	/// Test hooks: drive the host window like a user would.
+	void testHostWithVisibility(int comboIndex);
+	bool hostControlsVisible() const;
 };
 
 }

--- a/src/CoopMod/LobbyMenu.cpp
+++ b/src/CoopMod/LobbyMenu.cpp
@@ -36,6 +36,13 @@
 #include "../Interface/ArrowButton.h"
 
 #include "HostMenu.h"
+#include "../Geoscape/GeoscapeState.h"
+#include "../Geoscape/Globe.h"
+#include "../Geoscape/BaseNameState.h"
+#include "../Geoscape/BuildNewBaseState.h"
+#include "../Basescape/PlaceLiftState.h"
+#include "../Menu/NewGameState.h"
+#include "../Savegame/Base.h"
 
 namespace OpenXcom
 {
@@ -108,7 +115,7 @@ struct comparePlayerLatency
 LobbyMenu::LobbyMenu() : _sortable(true)
 {
 
-	connectionTCP::isLobbyMenuClosed = false;
+	connectionTCP::session.markLobbyOpen();
 
 	// coop chat menu
 	if (!_game->getCoopMod()->getChatMenu())
@@ -188,6 +195,21 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 	_btnCancel->onMouseClick((ActionHandler)&LobbyMenu::btnCancelClick);
 	_btnCancel->onKeyboardPress((ActionHandler)&LobbyMenu::btnCancelClick, Options::keyCancel);
 
+	// Campaign lobbies are host-driven: clients have no ready/start button
+	// at all (flow-redesign D4)
+	if (connectionTCP::session.lobbyMode != 0)
+	{
+		if (_game->getCoopMod()->getServerOwner() == true)
+		{
+			_btnCancel->setText(connectionTCP::session.lobbyMode == 1 ? "START CAMPAIGN" : "RESUME CAMPAIGN");
+			_btnCancel->setVisible(false); // shown once eligible (think())
+		}
+		else
+		{
+			_btnCancel->setVisible(false);
+		}
+	}
+
 	_txtTitle->setBig();
 	_txtTitle->setAlign(ALIGN_CENTER);
 
@@ -219,7 +241,7 @@ LobbyMenu::LobbyMenu() : _sortable(true)
 		_txtChangeTeam->setVisible(false);
 	}
 
-	if (connectionTCP::isCoopSessionLocked == true)
+	if (connectionTCP::session.sessionLocked == true)
 	{
 		_txtChangeTeam->setVisible(false);
 	}
@@ -379,12 +401,285 @@ void LobbyMenu::updateArrows()
  * Returns to the previous screen.
  * @param action Pointer to an action.
  */
+/**
+ * Confirmation dialog for START CAMPAIGN: the player set and teams are
+ * locked once the campaign begins (flow-redesign D3). File-local.
+ */
+class ConfirmStartCampaignState : public State
+{
+private:
+	LobbyMenu *_lobby;
+	Window *_window;
+	Text *_txtMessage;
+	TextButton *_btnOk, *_btnCancel;
+public:
+	ConfirmStartCampaignState(LobbyMenu *lobby) : _lobby(lobby)
+	{
+		_screen = false;
+
+		_window = new Window(this, 256, 100, 32, 50, POPUP_BOTH);
+		_txtMessage = new Text(240, 48, 40, 60);
+		_btnOk = new TextButton(100, 16, 44, 124);
+		_btnCancel = new TextButton(100, 16, 176, 124);
+
+		setInterface("geoscape", true, _game->getSavedGame() ? _game->getSavedGame()->getSavedBattle() : 0);
+
+		add(_window, "window", "saveMenus");
+		add(_txtMessage, "text", "saveMenus");
+		add(_btnOk, "button", "saveMenus");
+		add(_btnCancel, "button", "saveMenus");
+
+		centerAllSurfaces();
+
+		setWindowBackground(_window, "saveMenus");
+
+		_txtMessage->setAlign(ALIGN_CENTER);
+		_txtMessage->setWordWrap(true);
+		_txtMessage->setText("Once the campaign starts, the number and names of the players cannot be changed. Are you sure you want to start?");
+
+		_btnOk->setText("OK");
+		_btnOk->onMouseClick((ActionHandler)&ConfirmStartCampaignState::btnOkClick);
+		_btnCancel->setText("CANCEL");
+		_btnCancel->onMouseClick((ActionHandler)&ConfirmStartCampaignState::btnCancelClick);
+		_btnCancel->onKeyboardPress((ActionHandler)&ConfirmStartCampaignState::btnCancelClick, Options::keyCancel);
+	}
+
+	void btnOkClick(Action *)
+	{
+		LobbyMenu *lobby = _lobby;
+		_game->popState(); // this dialog
+		// PRD-10 C4: re-check at the commit point - a client may have dropped
+		// while this dialog was open. If so, do NOT start; the lobby underneath
+		// already shows the not-eligible state (START button hidden, the ctor's
+		// "Waiting for players on port X" details). startCampaign() also guards
+		// defensively, but bail here so no side effect is even attempted.
+		if (!lobby->startEligible())
+		{
+			Log(LOG_INFO) << "[coop] START CAMPAIGN aborted: lobby no longer eligible at confirm time";
+			return;
+		}
+		lobby->startCampaign();
+	}
+
+	void btnCancelClick(Action *)
+	{
+		_game->popState(); // back to the lobby
+	}
+
+	// PRD-10 C4: nothing else pops this dialog when a client drops (only the top
+	// state's think() runs, so the lobby underneath is dormant). Watch
+	// eligibility here and dismiss ourselves the moment the lone client leaves,
+	// so the host never confirms a start into a departed roster. btnOkClick
+	// re-checks too, covering the click-before-this-fires race.
+	void think() override
+	{
+		State::think();
+		if (!_lobby->startEligible())
+		{
+			Log(LOG_INFO) << "[coop] START CAMPAIGN confirm dialog dismissed: client left the lobby";
+			_game->popState();
+		}
+	}
+};
+
+bool LobbyMenu::startEligible() const
+{
+	// >= 1 non-host client attached (D3); N=1 transport today. NOT
+	// getCoopStatic(): onConnect==1 merely means the host is listening.
+	return connectionTCP::session.clientInLobby;
+}
+
+std::string LobbyMenu::actionButtonText() const
+{
+	return _btnCancel->getText();
+}
+
+bool LobbyMenu::actionButtonVisible() const
+{
+	return _btnCancel->getVisible();
+}
+
+std::string LobbyMenu::detailsText() const
+{
+	return _txtDetails->getText();
+}
+
+std::vector<std::string> LobbyMenu::rosterNames() const
+{
+	std::vector<std::string> names;
+	for (const auto &p : _connectedPlayers)
+	{
+		names.push_back(p.name);
+	}
+	return names;
+}
+
+std::vector<std::string> LobbyMenu::missingPlayers() const
+{
+	// registered players (minus the host) not currently connected
+	std::vector<std::string> missing;
+	if (!_game->getSavedGame())
+	{
+		return missing;
+	}
+	std::string hostName = _game->getCoopMod()->getHostName();
+	std::string connectedClient = connectionTCP::session.clientInLobby
+									  ? _game->getCoopMod()->getCurrentClientName()
+									  : "";
+	for (const auto &p : _game->getSavedGame()->getCoopPlayers())
+	{
+		if (p != hostName && p != connectedClient)
+		{
+			missing.push_back(p);
+		}
+	}
+	return missing;
+}
+
+void LobbyMenu::resumeCampaign()
+{
+
+	connectionTCP::session.campaignStarted();
+	// battle save: after the geoscape world ack, stream the battle (2c)
+	connectionTCP::session.armResumeHandshake(_game->getSavedGame()->getSavedBattle() != nullptr);
+
+	// Serve the connected client its world: stored blob if we have one,
+	// otherwise a fresh world + base building (registered-no-blob, D6).
+	std::string clientName = _game->getCoopMod()->getCurrentClientName();
+	if (connectionTCP::hasCoopFile(connectionTCP::hostBlobKey(clientName)))
+	{
+		Json::Value root;
+		root["state"] = "campaign_resume";
+		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+	}
+	else
+	{
+		Json::Value root = connectionTCP::buildCampaignStartPacket(_game->getSavedGame());
+		_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+	}
+
+	// close the lobby (popping anything stacked above it) and hold until
+	// every player reports its world loaded
+	closeLobby();
+
+	_game->pushState(new CoopState(COOP_DLG_RESUME_ACK_WAIT));
+
+}
+
+void LobbyMenu::openStartConfirmDialog()
+{
+	_game->pushState(new ConfirmStartCampaignState(this));
+}
+
+bool LobbyMenu::clickStartConfirmOk()
+{
+	if (_game->getStates().empty())
+	{
+		return false;
+	}
+	ConfirmStartCampaignState *dlg = dynamic_cast<ConfirmStartCampaignState *>(_game->getStates().back());
+	if (!dlg)
+	{
+		return false;
+	}
+	dlg->btnOkClick(nullptr); // the real click path: pop + re-check + maybe start
+	return true;
+}
+
+void LobbyMenu::startCampaign()
+{
+
+	// PRD-10 C4: never start with a departed roster. Every UI path re-checks
+	// before reaching here, but guard defensively for any direct caller (the
+	// harness lobby_start_campaign command calls this). No side effects on refusal.
+	if (!startEligible())
+	{
+		Log(LOG_INFO) << "[coop] startCampaign refused: lobby no longer start-eligible (client left)";
+		return;
+	}
+
+	// lock players and teams (change_team refuses while locked)
+	connectionTCP::session.campaignStarted();
+
+	// A NEW campaign always mints a fresh saveID and starts with no world blobs
+	// (fixes C2: a second campaign in the same process must not reuse the first
+	// campaign's ID or serve its stale client world). resumeCampaign keeps the
+	// loaded ID. The campaign_start packet built below carries this fresh ID and
+	// the client adopts it (connectionTCP campaign_start handler); the join-time
+	// mint (connectionTCP ~7149) remains only as a handshake fallback.
+	connectionTCP::saveID = _game->getCoopMod()->getDateTimeCoop();
+	{
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+		connectionTCP::coopFilesHost.clear();
+		connectionTCP::coopFilesClient.clear();
+	}
+
+	// the locked player list, host first (D4/D6)
+	std::vector<std::string> players;
+	players.push_back(_game->getCoopMod()->getHostName());
+	players.push_back(_game->getCoopMod()->getCurrentClientName());
+	_game->getSavedGame()->setCoopPlayers(players);
+	_game->getSavedGame()->setCoopSave(true);
+
+	// initial save right at START so a crash during base building resumes
+	// into base placement (D6). Direct write: the funnel's client-progress
+	// pull has nothing to pull yet.
+	try
+	{
+		_game->getSavedGame()->save("_autogeo_.asav", _game->getMod());
+	}
+	catch (const std::exception &e)
+	{
+		Log(LOG_ERROR) << "[coop] initial campaign save failed: " << e.what();
+	}
+
+	// clients: create their worlds and start base building
+	Json::Value root = connectionTCP::buildCampaignStartPacket(_game->getSavedGame());
+	_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+
+	// host: close the lobby (popping whatever sits above it, e.g. the
+	// Profile pushed by the join handshake) and place the first base
+	closeLobby();
+
+	GeoscapeState *gs = nullptr;
+	for (auto *s : _game->getStates())
+	{
+		if (auto *g = dynamic_cast<GeoscapeState *>(s))
+		{
+			gs = g;
+		}
+	}
+
+	beginInitialBasePlacement(_game, gs, _game->getSavedGame()->getBases()->back());
+
+}
+
 void LobbyMenu::btnCancelClick(Action*)
 {
 
+	// campaign lobby: the button is START/RESUME CAMPAIGN, host only (D3/D4)
+	if (connectionTCP::session.lobbyMode != 0)
+	{
+		if (connectionTCP::session.lobbyMode == 1
+			&& _game->getCoopMod()->getServerOwner() == true
+			&& connectionTCP::session.sessionLocked == false
+			&& startEligible())
+		{
+			_game->pushState(new ConfirmStartCampaignState(this));
+		}
+		else if (connectionTCP::session.lobbyMode == 2
+			&& _game->getCoopMod()->getServerOwner() == true
+			&& missingPlayers().empty()
+			&& startEligible())
+		{
+			resumeCampaign();
+		}
+		return;
+	}
+
 	connectionTCP::isPlayerReady = !connectionTCP::isPlayerReady;
 
-	if (connectionTCP::isCoopSessionLocked == false && _game->getCoopMod()->getCoopStatic() == true)
+	if (connectionTCP::session.sessionLocked == false && _game->getCoopMod()->getCoopStatic() == true)
 	{
 
 		if (_game->getCoopMod()->isCoopSession() == true && _game->getCoopMod()->getServerOwner() == true)
@@ -411,13 +706,13 @@ void LobbyMenu::btnCancelClick(Action*)
 
 		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true)
 		{
-			connectionTCP::isCoopSessionLocked = true;
+			connectionTCP::session.campaignStarted();
 		}
 
 	}
 	else if (_game->getCoopMod()->getCoopStatic() == true && _game->getCoopMod()->isCoopSession() == true)
 	{
-		connectionTCP::isLobbyMenuClosed = true;
+		connectionTCP::session.markLobbyClosed();
 		_game->popState();
 
 		if (connectionTCP::LobbyFileStatus == 1 && _game->getCoopMod()->getCoopStatic() == true)
@@ -456,7 +751,7 @@ void LobbyMenu::btnCancelClick(Action*)
 
 		if (_game->getCoopMod()->getServerOwner() == false)
 		{
-			connectionTCP::isLobbyMenuClosed = true;
+			connectionTCP::session.markLobbyClosed();
 			_game->popState();
 			_game->getCoopMod()->disconnectTCP(true);
 		}
@@ -465,34 +760,65 @@ void LobbyMenu::btnCancelClick(Action*)
 
 }
 
+void LobbyMenu::pushServerListUnlessPresent()
+{
+	for (auto* s : _game->getStates())
+	{
+		if (dynamic_cast<ServerList*>(s) != nullptr)
+		{
+			return; // the browser we came from is already underneath
+		}
+	}
+	_game->pushState(new ServerList());
+}
+
+void LobbyMenu::closeLobby()
+{
+	// pop everything above the lobby, then the lobby itself; the world/geoscape
+	// beneath survives and the session records that the lobby is gone.
+	connectionTCP::session.markLobbyClosed();
+	while (!_game->getStates().empty())
+	{
+		bool isLobby = dynamic_cast<LobbyMenu*>(_game->getStates().back()) != nullptr;
+		_game->popState();
+		if (isLobby)
+		{
+			break;
+		}
+	}
+}
+
 void LobbyMenu::btnDisconnectClick(Action* action)
 {
 
-	connectionTCP::isLobbyMenuClosed = true;
+	connectionTCP::session.markLobbyClosed();
 
 	_game->popState();
 
-	// If the host presses the disconnect button and is allowed to save player progress, disconnect and return to the Host menu
-	if (Options::HostSaveProgress == true && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
+	// Disconnect BEFORE dropping the role: the teardown classifies the
+	// machine from session.role, and falsifying it first made the cleanup run
+	// the client path on a host (the disconnect->cancel bug family).
+	// If the host presses the disconnect button, disconnect and return to the Host menu
+	if (_game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
 	{
-		_game->getCoopMod()->setServerOwner(false);
 		_game->getCoopMod()->disconnectTCP(true);
+		_game->getCoopMod()->setServerOwner(false);
 		_game->pushState(new HostMenu());
 	}
-	// If the client presses Disconnect and the host is allowed to save player progress, or there are no bases, disconnect and return to the main menu
-	else if ((Options::HostSaveProgress == true || connectionTCP::no_bases == true) && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == false)
+	// If the client presses Disconnect, disconnect and return to the main menu
+	else if (_game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == false)
 	{
-		_game->getCoopMod()->setServerOwner(false);
 		_game->getCoopMod()->disconnectTCP();
-		_game->pushState(new ServerList());
+		_game->getCoopMod()->setServerOwner(false);
+		pushServerListUnlessPresent();
 	}
 	// Otherwise, do nothing and just return to the server list
 	else
 	{
-		_game->getCoopMod()->setServerOwner(false);
 		// Prevent returning to the main menu
 		_game->getCoopMod()->disconnectTCP(true);
-		_game->pushState(new ServerList());
+		_game->getCoopMod()->setServerOwner(false);
+		pushServerListUnlessPresent();
 	}
 
 }
@@ -548,7 +874,7 @@ void LobbyMenu::lstSavesPress(Action* action)
 {
 
 	// The host switches a player to another team.
-	if (_game->getCoopMod()->getServerOwner() == true && action->getDetails()->button.button == SDL_BUTTON_LEFT && connectionTCP::isCoopSessionLocked == false)
+	if (_game->getCoopMod()->getServerOwner() == true && action->getDetails()->button.button == SDL_BUTTON_LEFT && connectionTCP::session.sessionLocked == false)
 	{
 		auto connectedPlayer = _connectedPlayers;  
 		int sel = _lstPlayers->getSelectedRow() - _firstValidRow;
@@ -664,10 +990,20 @@ void LobbyMenu::think()
 
 	if (_game->getCoopMod()->getServerOwner() == false && _game->getCoopMod()->getCoopStatic() == false)
 	{
-		
-		_game->popState();
 
-		_game->pushState(new ServerList());
+		// Connection gone: leave the lobby ONCE, and reuse a server browser
+		// already underneath instead of stacking a fresh one on top of it
+		// (repeated pushes made CANCEL act on a stale browser).
+		if (!_redirected && !_game->getStates().empty() && _game->getStates().back() == this)
+		{
+			_redirected = true;
+
+			_game->popState();
+
+			pushServerListUnlessPresent();
+		}
+
+		return;
 
 	}
 
@@ -726,7 +1062,48 @@ void LobbyMenu::think()
 		// status
 		std::string txtStatus = " ";
 
-		if (connectionTCP::isCoopSessionLocked == false)
+		if (connectionTCP::session.lobbyMode != 0)
+		{
+			// Campaign lobby: host-driven, no ready dance. The host's button
+			// appears once starting is possible (D3/D4).
+			if (_game->getCoopMod()->getServerOwner() == true && connectionTCP::session.sessionLocked == false)
+			{
+				if (connectionTCP::session.lobbyMode == 1)
+				{
+					_btnCancel->setText("START CAMPAIGN");
+					_btnCancel->setVisible(startEligible());
+				}
+				else if (connectionTCP::session.lobbyMode == 2)
+				{
+					// resume gate: all registered players must be present
+					std::vector<std::string> missing = missingPlayers();
+					if (missing.empty())
+					{
+						_btnCancel->setText("RESUME CAMPAIGN");
+						_btnCancel->setVisible(startEligible());
+						_txtDetails->setText(tr("STR_DETAILS").arg("All players connected"));
+					}
+					else
+					{
+						_btnCancel->setVisible(false);
+						// merged form: names AND port (the ctor's generic
+						// "Waiting for players on port X" covers the no-names case)
+						std::string wait = "Waiting for ";
+						for (size_t i = 0; i < missing.size(); ++i)
+						{
+							if (i > 0)
+							{
+								wait += ", ";
+							}
+							wait += missing[i];
+						}
+						wait += " on port " + std::to_string(tcp_port);
+						_txtDetails->setText(tr("STR_DETAILS").arg(wait));
+					}
+				}
+			}
+		}
+		else if (connectionTCP::session.sessionLocked == false)
 		{
 
 			std::string txtTimer = "";
@@ -757,7 +1134,7 @@ void LobbyMenu::think()
 				// Do something after one minute
 				Json::Value root;
 				root["state"] = "lobby_ready";
-				connectionTCP::isCoopSessionLocked = true;
+				connectionTCP::session.campaignStarted();
 
 				_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
 
@@ -792,8 +1169,16 @@ void LobbyMenu::think()
 		itHost->team = txtTeam;
 		itHost->details = txtDetails;
 		
-		// other players
-		if (_game->getCoopMod()->getCoopStatic() == true && _game->getCoopMod()->isCoopSession() == true)
+		// other players. Machine-aware presence: the HOST shows a peer only
+		// once it passed every join gate (clientInLobby - a refused wrong-name
+		// attempt must never flash into the roster); the CLIENT shows its
+		// host as soon as it is attached (coopStatic).
+		bool peerPresent = _game->getCoopMod()->getServerOwner()
+							   ? connectionTCP::session.clientInLobby
+							   : _game->getCoopMod()->getCoopStatic() == true;
+		if (peerPresent
+			&& (connectionTCP::session.lobbyMode != 0
+				|| _game->getCoopMod()->isCoopSession() == true))
 		{
 			const int playerId = 2; // fix later...
 
@@ -815,7 +1200,7 @@ void LobbyMenu::think()
 			// status
 			std::string txtStatus2 = "";
 
-			if (connectionTCP::isCoopSessionLocked == false)
+			if (connectionTCP::session.lobbyMode == 0 && connectionTCP::session.sessionLocked == false)
 			{
 
 				if (connectionTCP::isPlayersReady == true)

--- a/src/CoopMod/LobbyMenu.h
+++ b/src/CoopMod/LobbyMenu.h
@@ -51,6 +51,7 @@ protected:
 	unsigned int _firstValidRow = 0;
 	bool _sortable;
 	bool _timerStarted = false;
+	bool _redirected = false; // think() left the lobby after a lost connection
 	int _countdown = 30; // seconds
 	void updateArrows();
   public:
@@ -67,6 +68,11 @@ protected:
 	/// Handler for clicking the Cancel button.
 	void btnCancelClick(Action *action);
 	void btnDisconnectClick(Action* action);
+	/// Returns to the server browser, reusing one already in the stack.
+	void pushServerListUnlessPresent();
+	// Pop everything stacked above the LobbyMenu (inclusive) and mark the
+	// session's lobby closed. Shared by startCampaign() and resumeCampaign().
+	void closeLobby();
 	void btnChatClick(Action* action);
 	/// Handler for moving the mouse over a list item.
 	void lstSavesMouseOver(Action *action);
@@ -78,6 +84,27 @@ protected:
 	void disableSort();
 	/// Runs the timers and handles popups.
 	void think() override;
+	/// Can the host start the new campaign (>= 1 client connected)?
+	bool startEligible() const;
+	/// Locks players/teams, writes the initial save and begins base building
+	/// on every machine (flow-redesign F2).
+	void startCampaign();
+	/// PRD-10: push the real START CAMPAIGN confirm dialog (harness hook so a
+	/// test can exercise the true confirm->OK path, not a startCampaign bypass).
+	void openStartConfirmDialog();
+	/// PRD-10: if a confirm dialog is on top, invoke its OK exactly as a click
+	/// would (pops it, re-checks eligibility, starts only if still eligible).
+	/// Returns true if a confirm dialog was found and clicked.
+	bool clickStartConfirmOk();
+	/// Registered players not yet in the lobby (resume mode, F3).
+	std::vector<std::string> missingPlayers() const;
+	/// Serves every resuming player its world and waits for acks (F3).
+	void resumeCampaign();
+	/// Introspection for the test harness.
+	std::string actionButtonText() const;
+	bool actionButtonVisible() const;
+	std::string detailsText() const;
+	std::vector<std::string> rosterNames() const;
 	/// Handler for clicking the Name arrow.
 	void sortNameClick(Action* action);
 	void sortLatencyClick(Action* action);

--- a/src/CoopMod/Profile.cpp
+++ b/src/CoopMod/Profile.cpp
@@ -108,10 +108,10 @@ void Profile::buttonOK(Action *)
 	_game->popState();
 
 	// save progress
-	if (_game->getCoopMod()->getServerOwner() == false && connectionTCP::_host_save_progress == true && connectionTCP::saveID != 0)
+	if (_game->getCoopMod()->getServerOwner() == false && connectionTCP::saveID != 0)
 	{
 
-		_game->pushState(new CoopState(52));
+		_game->pushState(new CoopState(COOP_DLG_CLIENT_LOAD_WAIT));
 
 		Json::Value root;
 

--- a/src/CoopMod/TestServer.cpp
+++ b/src/CoopMod/TestServer.cpp
@@ -78,11 +78,15 @@
 #include "../Mod/RuleResearch.h"
 #include "../Mod/RuleUfo.h"
 #include "../Menu/NewGameState.h"
+#include "../Menu/LoadGameState.h"
+#include "../Menu/SaveGameState.h"
 #include "../Menu/StartState.h"
+#include "../Menu/MainMenuState.h"
 #include "../Geoscape/BuildNewBaseState.h"
 #include "../Geoscape/BaseNameState.h"
 #include "../Geoscape/UfoDetectedState.h"
 #include "LobbyMenu.h"
+#include "HostMenu.h"
 #include "Profile.h"
 #include "connectionTCP.h"
 #include "ServerList.h"
@@ -96,6 +100,29 @@
 
 namespace OpenXcom
 {
+
+namespace {
+// PRD-13 S6: the state-stack scan `for (auto* s : game->getStates()) if (auto*
+// t = dynamic_cast<T*>(s)) found = t;` was pasted ~20x. These file-local helpers
+// replace the pure find-last and top-only variants. Loops with extra
+// per-iteration logic (early break, multi-type, counting) are left inline.
+
+/// Last (topmost) instance of T on the state stack, or nullptr.
+template <class T> T* findState(Game* game)
+{
+	T* found = nullptr;
+	for (auto* s : game->getStates())
+		if (auto* t = dynamic_cast<T*>(s)) found = t;
+	return found;
+}
+
+/// T only if it is the current top state, else nullptr.
+template <class T> T* topState(Game* game)
+{
+	return game->getStates().empty() ? nullptr
+		: dynamic_cast<T*>(game->getStates().back());
+}
+}
 
 TestServer& TestServer::instance()
 {
@@ -254,6 +281,7 @@ void TestServer::pump()
 	// worker thread; executing commands now races it (e.g. GeoscapeState
 	// needs surfaces that modResources() synthesizes at the very end of the
 	// load). Leave commands queued until loading finishes.
+	// PRD-13: left inline - returns on first match (presence check / early exit), not find-last
 	for (auto* s : _game->getStates())
 	{
 		if (dynamic_cast<StartState*>(s))
@@ -349,6 +377,7 @@ std::string TestServer::execute(const std::string& line)
 		else if (cmd == "get_state")
 		{
 			Json::Value states(Json::arrayValue);
+			// PRD-13: left inline - dumps every state's name into a container, not a find
 			for (auto* s : _game->getStates())
 			{
 				states.append(typeid(*s).name());
@@ -375,12 +404,7 @@ std::string TestServer::execute(const std::string& line)
 		else if (cmd == "server_combo")
 		{
 			// Dump the rendezvous-server combobox state for assertions.
-			ServerList* browser = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* sl = dynamic_cast<ServerList*>(s))
-					browser = sl;
-			}
+			ServerList* browser = findState<ServerList>(_game);
 
 			if (!browser)
 			{
@@ -409,12 +433,7 @@ std::string TestServer::execute(const std::string& line)
 		{
 			// Open the rendezvous-server dropdown so the disabled/greyed rows are
 			// visible for a screenshot.
-			ServerList* browser = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* sl = dynamic_cast<ServerList*>(s))
-					browser = sl;
-			}
+			ServerList* browser = findState<ServerList>(_game);
 			if (!browser)
 			{
 				resp["ok"] = false;
@@ -589,10 +608,7 @@ std::string TestServer::execute(const std::string& line)
 			// advances fast when BOTH players pick the SAME speed; the driver
 			// calls this on host+client together, then lets the real timers run.
 			int idx = req.get("idx", 0).asInt();
-			GeoscapeState* gs = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* g = dynamic_cast<GeoscapeState*>(s))
-					gs = g;
+			GeoscapeState* gs = findState<GeoscapeState>(_game);
 			if (!gs)
 				resp["error"] = "no GeoscapeState on stack (in a popup/battle?)";
 			else
@@ -649,9 +665,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "confirm_landing")
 		{
-			ConfirmLandingState* cl = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* c = dynamic_cast<ConfirmLandingState*>(s)) cl = c;
+			ConfirmLandingState* cl = findState<ConfirmLandingState>(_game);
 			if (!cl)
 				resp["error"] = "no ConfirmLandingState on stack";
 			else
@@ -665,9 +679,7 @@ std::string TestServer::execute(const std::string& line)
 			// Pre-battle coop inventory (soldiers spawn unarmed, weapons on the
 			// ground). action=autoequip_all cycles units auto-equipping each from
 			// the ground pile; action=ok closes it and starts the tactical turn.
-			InventoryState* inv = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* i = dynamic_cast<InventoryState*>(s)) inv = i;
+			InventoryState* inv = findState<InventoryState>(_game);
 			if (!inv)
 			{
 				resp["error"] = "no InventoryState on stack";
@@ -696,9 +708,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "close_briefing")
 		{
-			BriefingState* br = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* b = dynamic_cast<BriefingState*>(s)) br = b;
+			BriefingState* br = findState<BriefingState>(_game);
 			if (!br)
 				resp["error"] = "no BriefingState on stack";
 			else
@@ -770,6 +780,7 @@ std::string TestServer::execute(const std::string& line)
 			// BattlescapeState. All ops are on the main thread (race-free).
 			BattlescapeGame* bg = nullptr;
 			BattlescapeState* bstate = nullptr;
+			// PRD-13: left inline - assigns two vars + calls getBattleGame() per match, not pure find-last
 			for (auto* s : _game->getStates())
 				if (auto* bs = dynamic_cast<BattlescapeState*>(s)) { bstate = bs; bg = bs->getBattleGame(); }
 			SavedBattleGame* sbg = bg ? bg->getSave() : nullptr;
@@ -865,7 +876,7 @@ std::string TestServer::execute(const std::string& line)
 			// Confirm/close the top geoscape popup (event intro, etc.). Handled
 			// types grow as the play driver discovers them. Reports the type so
 			// unknown popups surface instead of silently hanging.
-			State* top = _game->getStates().empty() ? nullptr : _game->getStates().back();
+			State* top = topState<State>(_game);
 			resp["type"] = top ? typeid(*top).name() : "none";
 			if (auto* ev = dynamic_cast<GeoscapeEventState*>(top))
 			{
@@ -957,11 +968,13 @@ std::string TestServer::execute(const std::string& line)
 			resp["host"] = connectionTCP::getHost();
 			resp["serverOwner"] = connectionTCP::getServerOwner();
 			resp["onConnect"] = coop->isConnected();
-			resp["sessionLocked"] = connectionTCP::isCoopSessionLocked;
+			resp["sessionLocked"] = connectionTCP::session.sessionLocked;
 			resp["playerReady"] = connectionTCP::isPlayerReady;
 			resp["playersReady"] = connectionTCP::isPlayersReady;
-			resp["lobbyClosed"] = connectionTCP::isLobbyMenuClosed;
+			resp["lobbyClosed"] = connectionTCP::session.lobbyClosed;
 			resp["lobbyFileStatus"] = connectionTCP::LobbyFileStatus;
+			resp["lobbyMode"] = connectionTCP::session.lobbyMode;
+			resp["resumeAck"] = connectionTCP::session.resumeAck;
 			resp["coopSession"] = coop->isCoopSession();
 			resp["hasSave"] = _game->getSavedGame() != nullptr;
 			resp["inBattle"] = _game->getSavedGame() && _game->getSavedGame()->getSavedBattle();
@@ -969,6 +982,7 @@ std::string TestServer::execute(const std::string& line)
 			resp["clientName"] = coop->getCurrentClientName();
 			resp["insideCoopBase"] = coop->playerInsideCoopBase;
 			resp["saveID"] = Json::Value::Int64(connectionTCP::saveID);
+			resp["pendingHostSaveName"] = connectionTCP::session.pendingHostSaveName;
 			resp["ok"] = true;
 		}
 		else if (cmd == "load_save")
@@ -987,23 +1001,157 @@ std::string TestServer::execute(const std::string& line)
 			std::string port = req.get("port", "3000").asString();
 			std::string player = req.get("player", "HostPlayer").asString();
 
-			connectionTCP::password = "";
-			connectionTCP::isPasswordRequired = false;
-			connectionTCP::_coopGamemode = 1; // PVE
-			coop->setCoopSession(false);
-			coop->setPlayerTurn(3);
-			coop->setHostName(player);
 			// campaign when a real campaign save is loaded (same check as HostMenu)
 			bool campaign = _game->getSavedGame() && !_game->getSavedGame()->getCountries()->empty();
-			coop->setCoopCampaign(campaign);
-			coop->hostTCPServer(server, port);
-			coop->setServerOwner(true);
-			if (Options::HostSaveProgress && campaign)
+
+			// flow-redesign D1: solo campaigns can never be hosted as co-op
+			if (campaign && !_game->getSavedGame()->isCoopSave())
 			{
-				_game->pushState(new LobbyMenu());
+				resp["error"] = "solo campaign cannot be hosted (D1)";
 			}
-			resp["campaign"] = campaign;
+			// D4: the host identity is locked to the save
+			else if (campaign
+				&& !_game->getSavedGame()->getCoopPlayers().empty()
+				&& _game->getSavedGame()->getCoopPlayers()[0] != player)
+			{
+				resp["error"] = "campaign can only be hosted by " + _game->getSavedGame()->getCoopPlayers()[0] + " (D4)";
+			}
+			else
+			{
+				// same lobby-mode derivation as HostMenu::hostTCPGame
+				if (campaign)
+				{
+					connectionTCP::session.lobbyMode = _game->getSavedGame()->getCoopPlayers().empty() ? 1 : 2;
+				}
+				connectionTCP::password = "";
+				connectionTCP::isPasswordRequired = false;
+				connectionTCP::_coopGamemode = 1; // PVE
+				coop->setCoopSession(false);
+				coop->setPlayerTurn(3);
+				coop->setHostName(player);
+				coop->setCoopCampaign(campaign);
+				coop->hostTCPServer(server, port);
+				coop->setServerOwner(true);
+				if (campaign)
+				{
+					// replace an open HostMenu with the lobby (the UI path
+					// does this via hostTCPGame)
+					if (topState<HostMenu>(_game))
+					{
+						_game->popState();
+					}
+					_game->pushState(new LobbyMenu());
+				}
+				resp["campaign"] = campaign;
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "host_menu_host")
+		{
+			// drive the real host window: pick a connection type
+			// (0 TCP, 1 UDP private, 2 UDP public, 3 hotseat) and START HOST
+			HostMenu* hm = topState<HostMenu>(_game);
+			if (!hm)
+			{
+				resp["error"] = "no HostMenu on top";
+			}
+			else
+			{
+				hm->testHostWithVisibility(req.get("visibility", 0).asInt());
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "host_menu_state")
+		{
+			HostMenu* hm = findState<HostMenu>(_game);
+			resp["open"] = (hm != nullptr);
+			resp["controlsVisible"] = hm ? hm->hostControlsVisible() : false;
 			resp["ok"] = true;
+		}
+		else if (cmd == "host_menu_cancel")
+		{
+			HostMenu* hm = topState<HostMenu>(_game);
+			if (!hm)
+			{
+				resp["error"] = "no HostMenu on top";
+			}
+			else
+			{
+				hm->btnCancelClick(nullptr);
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "lobby_disconnect")
+		{
+			LobbyMenu* lobby = topState<LobbyMenu>(_game);
+			if (!lobby)
+			{
+				resp["error"] = "no LobbyMenu on top";
+			}
+			else
+			{
+				lobby->btnDisconnectClick(nullptr);
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "disconnect_to_menu")
+		{
+			// Return this instance to the main menu the way the in-game "abandon
+			// to main menu" path does: drop the transport and reset the session.
+			// MainMenuState::init() also calls resetSession(), so this exercises
+			// the real teardown that must return the process to a pristine coop
+			// identity (saveID 0, blob maps empty) for a second campaign.
+			coop->disconnectTCP(true);
+			coop->setServerOwner(false);
+			connectionTCP::session.resetSession();
+			_game->setState(new MainMenuState);
+			resp["ok"] = true;
+		}
+		else if (cmd == "coop_dialog_info")
+		{
+			// introspect the topmost CoopState dialog anywhere on the stack:
+			// its code, title text, back-button text + visibility. Used by the
+			// harness to assert dialog wording/scaling and to catch a lingering
+			// "Connecting..." (code 15) buried under the lobby.
+			CoopState* cs = findState<CoopState>(_game);
+			if (!cs)
+			{
+				resp["present"] = false;
+			}
+			else
+			{
+				resp["present"] = true;
+				resp["code"] = cs->getStateCode();
+				resp["title"] = cs->getTitleText();
+				resp["backText"] = cs->getBackText();
+				resp["backVisible"] = cs->isBackVisible();
+				resp["windowHeight"] = cs->getWindowHeight();
+			}
+			resp["ok"] = true;
+		}
+		else if (cmd == "coop_push_connecting")
+		{
+			// Mirror the real join UI (ServerList/DirectConnect), which pushes a
+			// "Connecting..." wait dialog (CoopState 15) before kicking off the
+			// async connect. join_tcp bypasses that UI, so tests that need the
+			// connecting-dialog scenario (e.g. the lingering-window bug) push it
+			// explicitly right before join_tcp.
+			_game->pushState(new CoopState(15));
+			resp["ok"] = true;
+		}
+		else if (cmd == "coop_dialog_back")
+		{
+			// click the back/RESUME/OK button of the top CoopState dialog
+			CoopState* cs = topState<CoopState>(_game);
+			if (!cs)
+			{
+				resp["error"] = "no CoopState on top";
+			}
+			else
+			{
+				cs->previous(nullptr);
+				resp["ok"] = true;
+			}
 		}
 		else if (cmd == "join_tcp")
 		{
@@ -1021,14 +1169,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "profile_ok")
 		{
-			Profile* profile = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* p = dynamic_cast<Profile*>(s))
-				{
-					profile = p;
-				}
-			}
+			Profile* profile = findState<Profile>(_game);
 			if (profile)
 			{
 				profile->buttonOK(nullptr);
@@ -1041,19 +1182,15 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "open_new_game")
 		{
-			_game->pushState(new NewGameState);
+			// mode: "solo" (default) or "coop" - mirrors the main menu's
+			// New Game dropdown (flow-redesign D1)
+			bool coop = req.get("mode", "solo").asString() == "coop";
+			_game->pushState(new NewGameState(coop));
 			resp["ok"] = true;
 		}
 		else if (cmd == "newgame_ok")
 		{
-			NewGameState* ng = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* n = dynamic_cast<NewGameState*>(s))
-				{
-					ng = n;
-				}
-			}
+			NewGameState* ng = findState<NewGameState>(_game);
 			if (ng)
 			{
 				ng->btnOkClick(nullptr);
@@ -1070,14 +1207,7 @@ std::string TestServer::execute(const std::string& line)
 			double lat = req.get("lat", 0.0).asDouble();
 			std::string name = req.get("name", "TestBase").asString();
 
-			BuildNewBaseState* build = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* b = dynamic_cast<BuildNewBaseState*>(s))
-				{
-					build = b;
-				}
-			}
+			BuildNewBaseState* build = findState<BuildNewBaseState>(_game);
 			if (!build)
 			{
 				resp["error"] = "no BuildNewBaseState in state stack";
@@ -1089,14 +1219,7 @@ std::string TestServer::execute(const std::string& line)
 			else
 			{
 				// placeAt pushed BaseNameState (first base); confirm the name.
-				BaseNameState* nameState = nullptr;
-				for (auto* s : _game->getStates())
-				{
-					if (auto* n = dynamic_cast<BaseNameState*>(s))
-					{
-						nameState = n;
-					}
-				}
+				BaseNameState* nameState = findState<BaseNameState>(_game);
 				if (nameState)
 				{
 					nameState->setNameAndConfirm(name);
@@ -1110,14 +1233,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "lobby_ready")
 		{
-			LobbyMenu* lobby = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* l = dynamic_cast<LobbyMenu*>(s))
-				{
-					lobby = l;
-				}
-			}
+			LobbyMenu* lobby = findState<LobbyMenu>(_game);
 			if (lobby)
 			{
 				lobby->btnCancelClick(nullptr);
@@ -1210,14 +1326,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "soldiers_ok")
 		{
-			SoldiersState* st = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* x = dynamic_cast<SoldiersState*>(s))
-				{
-					st = x;
-				}
-			}
+			SoldiersState* st = findState<SoldiersState>(_game);
 			if (st)
 			{
 				st->btnOkClick(nullptr);
@@ -1267,14 +1376,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "leave_base")
 		{
-			BasescapeState* st = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* x = dynamic_cast<BasescapeState*>(s))
-				{
-					st = x;
-				}
-			}
+			BasescapeState* st = findState<BasescapeState>(_game);
 			if (st)
 			{
 				st->btnGeoscapeClick(nullptr);
@@ -1398,6 +1500,7 @@ std::string TestServer::execute(const std::string& line)
 		else if (cmd == "get_notices")
 		{
 			Json::Value notices(Json::arrayValue);
+			// PRD-13: left inline - appends every match's category into a container, not a find
 			for (auto* s : _game->getStates())
 			{
 				if (auto* n = dynamic_cast<TransferNoticeState*>(s))
@@ -1410,14 +1513,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "dismiss_notice")
 		{
-			TransferNoticeState* st = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* x = dynamic_cast<TransferNoticeState*>(s))
-				{
-					st = x;
-				}
-			}
+			TransferNoticeState* st = findState<TransferNoticeState>(_game);
 			if (st)
 			{
 				st->btnOkClick(nullptr);
@@ -1430,14 +1526,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "cancel_dialog")
 		{
-			TransferSoldierMenu* st = nullptr;
-			for (auto* s : _game->getStates())
-			{
-				if (auto* x = dynamic_cast<TransferSoldierMenu*>(s))
-				{
-					st = x;
-				}
-			}
+			TransferSoldierMenu* st = findState<TransferSoldierMenu>(_game);
 			if (st)
 			{
 				st->btnCancelClick(nullptr);
@@ -1453,6 +1542,7 @@ std::string TestServer::execute(const std::string& line)
 			// First N palette entries of the top two states, for asserting
 			// that a dialog adopted its parent's palette (flicker check).
 			Json::Value states(Json::arrayValue);
+			// PRD-13: left inline - reads every state's palette into a container, not a find
 			auto& stack = _game->getStates();
 			for (auto* s : stack)
 			{
@@ -1522,6 +1612,34 @@ std::string TestServer::execute(const std::string& line)
 				resp["ok"] = true;
 			}
 		}
+		else if (cmd == "save_game_ui")
+		{
+			// Save through the real SaveGameState funnel (same path as the
+			// in-game autosaves/quicksave), unlike save_game which calls
+			// SavedGame::save directly. Exercises the coop save cycle and the
+			// client-side save suppression gate. Only the single-pop SaveTypes
+			// are exposed: SAVE_DEFAULT pops the save+pause menus it normally
+			// sits on, which don't exist when pushed from here.
+			std::string type = req.get("type", "").asString();
+			if (!_game->getSavedGame())
+			{
+				resp["error"] = "no loaded save";
+			}
+			else if (type == "auto_geoscape")
+			{
+				_game->pushState(new SaveGameState(OPT_GEOSCAPE, SAVE_AUTO_GEOSCAPE, _game->getScreen()->getPalette()));
+				resp["ok"] = true;
+			}
+			else if (type == "quick")
+			{
+				_game->pushState(new SaveGameState(OPT_GEOSCAPE, SAVE_QUICK, _game->getScreen()->getPalette()));
+				resp["ok"] = true;
+			}
+			else
+			{
+				resp["error"] = "need type (auto_geoscape|quick)";
+			}
+		}
 		else if (cmd == "client_reload_progress")
 		{
 			// Reconnect flow: ask the host for our world (same as the client
@@ -1542,6 +1660,135 @@ std::string TestServer::execute(const std::string& line)
 				resp["ok"] = true;
 			}
 		}
+		else if (cmd == "lobby_state")
+		{
+			// campaign-lobby introspection (flow-redesign F2)
+			LobbyMenu* lobby = findState<LobbyMenu>(_game);
+			resp["lobbyOpen"] = (lobby != nullptr);
+			resp["lobbyMode"] = connectionTCP::session.lobbyMode;
+			resp["sessionLocked"] = connectionTCP::session.sessionLocked;
+			resp["startEligible"] = (lobby != nullptr) && lobby->startEligible();
+			if (lobby)
+			{
+				resp["buttonText"] = lobby->actionButtonText();
+				resp["buttonVisible"] = lobby->actionButtonVisible();
+				resp["detailsText"] = lobby->detailsText();
+				int idx = 0;
+				for (const auto& n : lobby->rosterNames())
+				{
+					resp["players"][idx++] = n;
+				}
+			}
+			resp["ok"] = true;
+		}
+		else if (cmd == "load_save_menu")
+		{
+			// load through the real LoadGameState (runs the co-op routing:
+			// coop save -> host window + resume lobby) (flow-redesign F3)
+			std::string file = req.get("file", "").asString();
+			if (file.empty())
+			{
+				resp["error"] = "need file";
+			}
+			else
+			{
+				_game->pushState(new LoadGameState(OPT_MENU, file, _game->getScreen()->getPalette()));
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "lobby_resume_campaign")
+		{
+			// host clicks RESUME CAMPAIGN (flow-redesign F3)
+			LobbyMenu* lobby = findState<LobbyMenu>(_game);
+			if (!lobby)
+			{
+				resp["error"] = "no LobbyMenu in state stack";
+			}
+			else if (connectionTCP::session.lobbyMode != 2)
+			{
+				resp["error"] = "lobby is not in resume mode";
+			}
+			else if (!lobby->missingPlayers().empty())
+			{
+				std::string missing;
+				for (const auto& m : lobby->missingPlayers())
+				{
+					if (!missing.empty()) missing += ", ";
+					missing += m;
+				}
+				resp["error"] = "waiting for: " + missing;
+			}
+			else
+			{
+				lobby->resumeCampaign();
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "lobby_start_campaign")
+		{
+			// host clicks START CAMPAIGN + confirms (flow-redesign F2)
+			LobbyMenu* lobby = findState<LobbyMenu>(_game);
+			if (!lobby)
+			{
+				resp["error"] = "no LobbyMenu in state stack";
+			}
+			else if (connectionTCP::session.lobbyMode != 1)
+			{
+				resp["error"] = "lobby is not in new-campaign mode";
+			}
+			else if (req.get("confirm", "").asString() == "dialog")
+			{
+				// PRD-10: route through the REAL confirm dialog so the test drives
+				// ConfirmStartCampaignState::btnOkClick (the true UI path). Do NOT
+				// pre-check startEligible here - the dialog/OK path IS the gate.
+				lobby->openStartConfirmDialog();
+				resp["ok"] = true;
+			}
+			else if (!lobby->startEligible())
+			{
+				resp["error"] = "no client connected";
+			}
+			else
+			{
+				lobby->startCampaign();
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "lobby_confirm_ok")
+		{
+			// PRD-10: click OK on the START CAMPAIGN confirm dialog (the real
+			// ConfirmStartCampaignState::btnOkClick path, which re-checks
+			// eligibility before starting).
+			LobbyMenu* lobby = findState<LobbyMenu>(_game);
+			if (!lobby)
+			{
+				resp["error"] = "no LobbyMenu in state stack";
+			}
+			else
+			{
+				resp["clicked"] = lobby->clickStartConfirmOk();
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "save_markers")
+		{
+			// Co-op campaign markers of the live save (flow-redesign F0)
+			if (!_game->getSavedGame())
+			{
+				resp["error"] = "no loaded save";
+			}
+			else
+			{
+				resp["coop"] = _game->getSavedGame()->isCoopSave();
+				int idx = 0;
+				for (const auto& p : _game->getSavedGame()->getCoopPlayers())
+				{
+					resp["coopPlayers"][idx++] = p;
+				}
+				resp["saveID"] = Json::Value::Int64(connectionTCP::saveID);
+				resp["ok"] = true;
+			}
+		}
 		else if (cmd == "has_coop_file")
 		{
 			std::string key = req.get("key", "").asString();
@@ -1553,7 +1800,23 @@ std::string TestServer::execute(const std::string& line)
 			std::string name = req.get("name", "").asString();
 			if (name == "HostSaveProgress")
 			{
-				Options::HostSaveProgress = req.get("value", false).asBool();
+				// Removed option (host-save authority is the only mode now);
+				// accepted and ignored so older test scripts keep running.
+				resp["ok"] = true;
+			}
+			else if (name == "autosave")
+			{
+				Options::autosave = req.get("value", false).asBool();
+				resp["ok"] = true;
+			}
+			else if (name == "autosaveFrequency")
+			{
+				Options::autosaveFrequency = req.get("value", 5).asInt();
+				resp["ok"] = true;
+			}
+			else if (name == "oxceGeoAutosaveFrequency")
+			{
+				Options::oxceGeoAutosaveFrequency = req.get("value", 0).asInt();
 				resp["ok"] = true;
 			}
 			else
@@ -1767,11 +2030,9 @@ std::string TestServer::execute(const std::string& line)
 			// up the run and reports readiness. The driver polls geo_state between
 			// geo_run calls. Here we just (a) enable host-only time so the client
 			// mirrors, (b) select the requested speed, (c) drain any popup now.
-			GeoscapeState* gs = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* g = dynamic_cast<GeoscapeState*>(s)) gs = g;
+			GeoscapeState* gs = findState<GeoscapeState>(_game);
 			// Drain a single blocking popup if present (driver calls repeatedly).
-			State* top = _game->getStates().empty() ? nullptr : _game->getStates().back();
+			State* top = topState<State>(_game);
 			bool drained = false;
 			if (top && !dynamic_cast<GeoscapeState*>(top)
 			    && !dynamic_cast<BattlescapeState*>(top))
@@ -1816,9 +2077,7 @@ std::string TestServer::execute(const std::string& line)
 				for (auto* b : *sg->getBases())
 					for (auto* c : *b->getCrafts())
 						if (c->getId() == craftId && c->coop == wantCoop) { craft = c; break; }
-			GeoscapeState* geo = nullptr;
-			for (auto* s : _game->getStates())
-				if (auto* g = dynamic_cast<GeoscapeState*>(s)) geo = g;
+			GeoscapeState* geo = findState<GeoscapeState>(_game);
 			if (!craft) resp["error"] = "no matching craft";
 			else if (!geo) resp["error"] = "no geoscape";
 			else

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -48,6 +48,11 @@
 
 #include "../Menu/NewGameState.h"
 #include "../Menu/LoadGameState.h"
+#include "../Geoscape/GeoscapeState.h"
+#include "../Geoscape/Globe.h"
+#include "../Geoscape/BaseNameState.h"
+#include "../Geoscape/BuildNewBaseState.h"
+#include "../Basescape/PlaceLiftState.h"
 
 #include "./connectionUDP/connection_rendezvous_glue.h"
 
@@ -78,6 +83,10 @@ bool sendFileHost = false;
 // allow sending a file to the host
 bool sendProgressSaveFileToHost = false;
 std::string sendProgressLoadFileToClient = "";
+// Snapshot of the resume blob, copied on the main thread when a
+// request_load_progress arrives so the streamer thread never touches the
+// shared blob maps for it.
+std::string sendProgressLoadBlob = "";
 // is the file to be sent a saved file?
 bool sendFileSave = false;
 // map data
@@ -101,7 +110,6 @@ int tcp_port = 3000;
 bool onTcpHost = false;
 
 // is the server owner the one who creates the server?
-bool server_owner = false;
 
 // the local server name
 std::string sendTcpServerName = "Server";
@@ -153,8 +161,6 @@ bool connectionTCP::_enable_xcom_equipment_aliens_pvp = true;
 
 bool connectionTCP::_unbalanced_craft_soldiers_limit = false;
 
-bool connectionTCP::_host_save_progress = false;
-
 bool connectionTCP::_coopCampaign = false;
 
 bool connectionTCP::_battleInit = false;
@@ -179,10 +185,159 @@ bool connectionTCP::pauseSound = false;
 
 bool connectionTCP::saveError = false;
 
+CoopSession connectionTCP::session;
+
+std::string connectionTCP::joinRefusalReason = "";
+
+// --- CoopSession transitions: every lifecycle change is logged. The mirrored
+// --- booleans ARE the encoding (PRD-12 S4 deleted the write-only phase enum);
+// --- every multi-field / cross-file write funnels through a named method here.
+
+void CoopSession::beginHosting()
+{
+	role = CoopRole::Host;
+	Log(LOG_INFO) << "[coop-session] beginHosting (role=Host)";
+}
+
+void CoopSession::beginJoining()
+{
+	role = CoopRole::Client;
+	Log(LOG_INFO) << "[coop-session] beginJoining (role=Client)";
+}
+
+void CoopSession::clientAttached()
+{
+	clientInLobby = true;
+	Log(LOG_INFO) << "[coop-session] clientAttached (clientInLobby=1)";
+}
+
+void CoopSession::campaignStarted()
+{
+	sessionLocked = true;
+	Log(LOG_INFO) << "[coop-session] campaignStarted (sessionLocked=1)";
+}
+
+void CoopSession::sessionLive()
+{
+	// waiting dialogs released; play begins/resumes. No boolean of its own -
+	// the surrounding flow already set lobbyClosed/campaignBegun; this is the
+	// lifecycle marker in the log.
+	Log(LOG_INFO) << "[coop-session] sessionLive";
+}
+
+void CoopSession::freeze()
+{
+	// a registered player dropped mid-session (D5). The freeze dialog + the
+	// preserved lobby/campaign booleans carry the state; this marks it in the log.
+	Log(LOG_INFO) << "[coop-session] freeze (lobbyMode=" << lobbyMode
+		<< " locked=" << sessionLocked << ")";
+}
+
+void CoopSession::setRole(CoopRole r)
+{
+	role = r;
+	Log(LOG_INFO) << "[coop-session] setRole -> "
+		<< (r == CoopRole::Host ? "Host" : r == CoopRole::Client ? "Client" : "None");
+}
+
+void CoopSession::adoptResumeSave()
+{
+	lobbyMode = 2;
+	sessionLocked = false;
+	resumeAck = false;
+	Log(LOG_INFO) << "[coop-session] adoptResumeSave (lobbyMode=2, unlocked, ack cleared)";
+}
+
+void CoopSession::armResumeHandshake(bool hasBattle)
+{
+	resumeAck = false;
+	resumeBattlePending = hasBattle;
+	Log(LOG_INFO) << "[coop-session] armResumeHandshake (battlePending=" << hasBattle << ")";
+}
+
+void CoopSession::markLobbyOpen()
+{
+	lobbyClosed = false;
+	Log(LOG_INFO) << "[coop-session] markLobbyOpen (lobbyClosed=0)";
+}
+
+void CoopSession::markLobbyClosed()
+{
+	lobbyClosed = true;
+	Log(LOG_INFO) << "[coop-session] markLobbyClosed (lobbyClosed=1)";
+}
+
+void CoopSession::armDeferredSave(const std::string& name)
+{
+	pendingHostSaveName = name;
+	Log(LOG_INFO) << "[coop-session] armDeferredSave ('" << name << "')";
+}
+
+void CoopSession::clearDeferredSave()
+{
+	pendingHostSaveName.clear();
+	Log(LOG_INFO) << "[coop-session] clearDeferredSave";
+}
+
+void CoopSession::signalCampaignBegun()
+{
+	campaignBegun = true;
+	Log(LOG_INFO) << "[coop-session] signalCampaignBegun (campaignBegun=1)";
+}
+
+void CoopSession::consumeCampaignBegun()
+{
+	campaignBegun = false;
+	Log(LOG_INFO) << "[coop-session] consumeCampaignBegun (campaignBegun=0)";
+}
+
+void CoopSession::resetSession()
+{
+	Log(LOG_INFO) << "[coop-session] resetSession";
+	role = CoopRole::None;
+	lobbyMode = 0;
+	clientInLobby = false;
+	sessionLocked = false;
+	lobbyClosed = true;
+	resumeAck = false;
+	resumeBattlePending = false;
+	resumeBattleEligible.clear();
+	campaignBegun = false;
+	pendingHostSaveName.clear();
+
+	// Full teardown returns the process to a pristine coop identity so a later
+	// solo save (or a second campaign) does not inherit this session's saveID or
+	// its stale world blobs (fixes C1/C2). This is the ONLY teardown path;
+	// onClientDrop deliberately keeps both so the host can serve a rejoin (D5).
+	connectionTCP::saveID = 0;
+	{
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+		connectionTCP::coopFilesHost.clear();
+		connectionTCP::coopFilesClient.clear();
+	}
+}
+
+void CoopSession::onClientDrop()
+{
+	Log(LOG_INFO) << "[coop-session] onClientDrop";
+	clientInLobby = false;
+	resumeAck = false;
+	resumeBattlePending = false;
+	resumeBattleEligible.clear();
+	campaignBegun = false;
+	pendingHostSaveName.clear();
+	// role/lobbyMode/sessionLocked/lobbyClosed survive: the campaign context
+	// outlives a peer drop (D5) - the freeze dialog or waiting lobby takes
+	// over. The legacy new-battle lobby (mode 0) instead restarts its ready
+	// dance, so its lock is released here.
+	if (lobbyMode == 0)
+	{
+		sessionLocked = false;
+	}
+}
+
 bool connectionTCP::isPasswordRequired = false;
 std::string connectionTCP::password = "";
-
-bool connectionTCP::isCoopSessionLocked = false;
 
 bool connectionTCP::isPlayerReady = false;
 
@@ -192,11 +347,11 @@ int connectionTCP::LobbyFileStatus = -1;
 
 int connectionTCP::lobby_timer = -1;
 
+bool connectionTCP::loadProgressBusy = false;
+
 bool connectionTCP::forceCloseCoopStateMenu = false;
 
 bool connectionTCP::forceClosePasswordCheckMenu = false;
-
-bool connectionTCP::isLobbyMenuClosed = true;
 
 int connectionTCP::manuallyAddedServerRemoveID = -1;
 
@@ -220,6 +375,7 @@ int connectionTCP::daysPassed = 0;
 
 std::unordered_map<std::string, std::string> OpenXcom::connectionTCP::coopFilesHost{};
 std::unordered_map<std::string, std::string> OpenXcom::connectionTCP::coopFilesClient{};
+std::mutex OpenXcom::connectionTCP::coopFilesMutex;
 
 std::string current_ping = "";
 
@@ -446,6 +602,8 @@ void logError(const std::string& msg)
 
 bool connectionTCP::hasCoopFile(const std::string& key)
 {
+	std::lock_guard<std::mutex> lock(coopFilesMutex);
+
 	const auto& coopFiles = getServerOwner()
 								? coopFilesHost
 								: coopFilesClient;
@@ -453,9 +611,155 @@ bool connectionTCP::hasCoopFile(const std::string& key)
 	return coopFiles.find(key) != coopFiles.end();
 }
 
+std::string connectionTCP::hostBlobKey(const std::string& clientName)
+{
+	return "host_" + std::to_string(connectionTCP::saveID) + "_" + clientName + ".data";
+}
+
+// Single authority for "may this machine touch local saves". coopSession is the
+// file-scope global behind isCoopSession(); getCoopStatic()/getServerOwner() are
+// static. Solo (no session, not connected) or the host may use local .sav files;
+// a coop client may not (its world lives only in the host's save).
+bool connectionTCP::localSavesAllowed()
+{
+	return (!coopSession && !getCoopStatic()) || getServerOwner();
+}
+
+bool connectionTCP::localLoadsAllowed()
+{
+	// Same liveness terms the save gate uses, WITHOUT the host escape: a live
+	// session forbids local loads for everyone (C7). Solo / post-session: allowed.
+	return !coopSession && !getCoopStatic();
+}
+
+
+std::string connectionTCP::clientBlobKey(const std::string& hostName)
+{
+	return "client_" + std::to_string(connectionTCP::saveID) + "_" + hostName + ".data";
+}
+
+const std::string* connectionTCP::findHostClientBlob(const std::string& clientName)
+{
+	// Keys look like host_<saveID>_<clientName>.data. Match the EXACT name field
+	// (so "Bob" never matches "Super_Bob") and, among matches, keep the newest
+	// saveID (datetime ids are equal-width, so lexicographic compare orders
+	// them). Parsing lives here, not in SavedGame::save.
+	static const std::string prefix = "host_";
+	static const std::string ext = ".data";
+	const std::string* best = nullptr;
+	std::string bestId;
+	for (const auto& kv : coopFilesHost)
+	{
+		const std::string& k = kv.first;
+		if (kv.second.empty()
+			|| k.size() < prefix.size() + ext.size()
+			|| k.compare(0, prefix.size(), prefix) != 0
+			|| k.compare(k.size() - ext.size(), ext.size(), ext) != 0)
+			continue;
+		size_t idEnd = k.find('_', prefix.size());
+		if (idEnd == std::string::npos || k.size() < idEnd + 1 + ext.size())
+			continue;
+		std::string name = k.substr(idEnd + 1, k.size() - (idEnd + 1) - ext.size());
+		if (name != clientName)
+			continue;
+		std::string id = k.substr(prefix.size(), idEnd - prefix.size());
+		if (!best || id > bestId)
+		{
+			best = &kv.second;
+			bestId = id;
+		}
+	}
+	return best;
+}
+
+// One authority for the campaign_start packet (see header). Reads the player
+// roster from the save (host lobby start sets it just before calling this, so
+// save->getCoopPlayers() equals the freshly-built list).
+Json::Value connectionTCP::buildCampaignStartPacket(const SavedGame* save)
+{
+	Json::Value root;
+	root["state"] = "campaign_start";
+	root["difficulty"] = (int)save->getDifficulty();
+	root["gamemode"] = connectionTCP::_coopGamemode;
+	root["saveID"] = static_cast<Json::Int64>(connectionTCP::saveID);
+	int idx = 0;
+	for (const auto& p : save->getCoopPlayers())
+	{
+		root["players"][idx++] = p;
+	}
+	return root;
+}
+
+bool connectionTCP::inCoopCampaignContext() const
+{
+	return _game->getSavedGame()
+		&& !_game->getSavedGame()->getCountries()->empty()
+		&& _game->getSavedGame()->isCoopSave();
+}
+
+// Drop world-blob captures that key the same player under an older saveID, so
+// the maps hold one entry per player instead of growing with every saveID
+// regeneration. Matches the EXACT player-name field of the key
+// (<prefix><saveID>_<playerName>.data), never a suffix: the old "ends with
+// _<name>.data" test also matched a DIFFERENT player whose name ended in the
+// stored name (storing "Bob" erased "Super_Bob"'s world - CONFIRMED S8 data
+// loss). Names are compared field-for-field so no such collision is possible.
+static void eraseStaleBlobEntries(std::unordered_map<std::string, std::string>& files,
+								  const std::string& prefix,
+								  const std::string& playerName,
+								  const std::string& keepKey)
+{
+	for (auto it = files.begin(); it != files.end();)
+	{
+		const std::string& k = it->first;
+		bool stale = false;
+		if (k != keepKey
+			&& k.size() >= 5
+			&& k.compare(0, prefix.size(), prefix) == 0
+			&& k.compare(k.size() - 5, 5, ".data") == 0)
+		{
+			// player-name field: everything between the saveID's trailing
+			// underscore and the ".data" extension.
+			size_t idEnd = k.find('_', prefix.size());
+			if (idEnd != std::string::npos && k.size() >= idEnd + 1 + 5)
+			{
+				std::string name = k.substr(idEnd + 1, k.size() - (idEnd + 1) - 5);
+				stale = (name == playerName);
+			}
+		}
+		if (stale)
+			it = files.erase(it);
+		else
+			++it;
+	}
+}
+
+namespace {
+// PRD-11 C13: thrown by the streamer's ack-wait loops when the connection is
+// torn down mid-transfer, so the streamer abandons the stream instead of
+// parking forever on isWaitMap while still holding sendFileClient.
+struct StreamAbort {};
+}
+
 // in the loop, load the map file data between host and client
 void connectionTCP::loopData()
 {
+	// Wait for the client's map-chunk ack (isWaitMap), but bail out if the
+	// connection is being torn down so a mid-transfer drop cannot park this
+	// thread. The teardown signal is disconnectTCP forcing BOTH send flags false
+	// (a live transfer always holds exactly one of them true); the destructor
+	// sets _stop. coopSession is NOT a reliable "streaming" signal here - the
+	// redesigned resume/rejoin flows stream a world without the old ready
+	// handshake that sets it, so keying on it aborts legitimate streams.
+	auto waitForMapAck = [&]() {
+		while (!isWaitMap)
+		{
+			if (_stop || (!sendFileClient && !sendFileHost))
+				throw StreamAbort{};
+			SDL_Delay(20);
+		}
+	};
+
 	while (!_stop)
 	{
 		try
@@ -479,14 +783,15 @@ void connectionTCP::loopData()
 					filepath = "battlehost";
 				}
 	
-				std::ifstream fileStream;
 				std::istringstream memoryStream;
 				std::istream* myfile = nullptr;
 
 				if (sendProgressLoadFileToClient == "")
 				{
 					// Read from memory
-					const auto& coopFiles = server_owner
+					std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+
+					const auto& coopFiles = getServerOwner()
 												? connectionTCP::coopFilesHost
 												: connectionTCP::coopFilesClient;
 
@@ -501,14 +806,10 @@ void connectionTCP::loopData()
 				}
 				else
 				{
-					// Read from file
-					fileStream.open(filepath);
-					if (!fileStream.is_open())
-					{
-						throw std::runtime_error("Failed to open file: " + filepath);
-					}
-
-					myfile = &fileStream;
+					// Resume blob, snapshotted on the main thread when the
+					// request_load_progress arrived (nothing streams from disk)
+					memoryStream.str(sendProgressLoadBlob);
+					myfile = &memoryStream;
 				}
 
 				std::string line;
@@ -516,8 +817,7 @@ void connectionTCP::loopData()
 
 				while (std::getline(*myfile, line))
 				{
-					while (!isWaitMap)
-						SDL_Delay(20);
+					waitForMapAck();
 
 					std::cout << line << std::endl;
 					if (fileindex != 0)
@@ -538,8 +838,7 @@ void connectionTCP::loopData()
 						isWaitMap = true;
 						for (unsigned i = 0; i < result.length(); i += 3000)
 						{
-							while (!isWaitMap)
-								SDL_Delay(20);
+							waitForMapAck();
 
 							isWaitMap = false;
 
@@ -560,8 +859,7 @@ void connectionTCP::loopData()
 				obj["data"] = result;
 				sendTCPPacketStaticData(obj.toStyledString());
 
-				while (!isWaitMap)
-					SDL_Delay(20);
+				waitForMapAck();
 
 				std::string jsonData = sendFileBase
 										   ? "{\"state\" : \"MAP_RESULT_CLIENT_BASE\"}"
@@ -577,6 +875,7 @@ void connectionTCP::loopData()
 				sendFileClient = false;
 				sendFileSave = false;
 				sendProgressLoadFileToClient = "";
+				sendProgressLoadBlob = "";
 			}
 			else if (sendFileHost)
 			{
@@ -586,7 +885,7 @@ void connectionTCP::loopData()
 
 				if (sendProgressSaveFileToHost)
 				{
-					filepath = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+					filepath = clientBlobKey(_game->getCoopMod()->getHostName());
 				}
 				else if (sendFileSave)
 				{
@@ -605,27 +904,33 @@ void connectionTCP::loopData()
 					filepath = "battlehost";
 				}
 
-				const auto& coopFiles = server_owner
-											? connectionTCP::coopFilesHost
-											: connectionTCP::coopFilesClient;
-
 				std::string coopKey = filepath; // tai filename, jos mapin avain on filename
 
-				auto it = coopFiles.find(coopKey);
-				if (it == coopFiles.end())
+				std::string blobCopy;
 				{
-					throw std::runtime_error("Failed to read from hash map with key: " + coopKey);
+					std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+
+					const auto& coopFiles = getServerOwner()
+												? connectionTCP::coopFilesHost
+												: connectionTCP::coopFilesClient;
+
+					auto it = coopFiles.find(coopKey);
+					if (it == coopFiles.end())
+					{
+						throw std::runtime_error("Failed to read from hash map with key: " + coopKey);
+					}
+
+					blobCopy = it->second;
 				}
 
-				std::istringstream myfile(it->second);
+				std::istringstream myfile(blobCopy);
 
 				std::string line;
 				std::string result;
 
 				while (getline(myfile, line))
 				{
-					while (!isWaitMap)
-						SDL_Delay(20);
+					waitForMapAck();
 
 					std::cout << line << std::endl;
 					if (fileindex != 0)
@@ -646,8 +951,7 @@ void connectionTCP::loopData()
 						isWaitMap = true;
 						for (unsigned i = 0; i < result.length(); i += 3000)
 						{
-							while (!isWaitMap)
-								SDL_Delay(20);
+							waitForMapAck();
 
 							isWaitMap = false;
 
@@ -668,8 +972,7 @@ void connectionTCP::loopData()
 				obj["data"] = result;
 				sendTCPPacketStaticData(obj.toStyledString());
 
-				while (!isWaitMap)
-					SDL_Delay(20);
+				waitForMapAck();
 
 				std::string jsonData = sendFileBase
 										   ? "{\"state\" : \"MAP_RESULT_HOST_BASE\"}"
@@ -686,6 +989,20 @@ void connectionTCP::loopData()
 				sendFileSave = false;
 				sendProgressSaveFileToHost = false;
 			}
+		}
+		catch (const StreamAbort&)
+		{
+			// PRD-11 C13: connection torn down mid-transfer. Abandon the stream
+			// and release every send flag so the streamer returns to idle instead
+			// of parking with sendFileClient still set.
+			Log(LOG_INFO) << "[coop] streamer: connection torn down mid-transfer, abandoning stream";
+			sendFileBase = false;
+			sendFileClient = false;
+			sendFileHost = false;
+			sendFileSave = false;
+			sendProgressLoadFileToClient = "";
+			sendProgressLoadBlob = "";
+			sendProgressSaveFileToHost = false;
 		}
 		catch (const std::exception& e)
 		{
@@ -957,7 +1274,7 @@ void connectionTCP::pushProgressToHostSilently()
 	// window before the own-world reload (GeoscapeState::init) has run. In all
 	// of those the live save is the PEER's world; uploading it would overwrite
 	// our own-world blob with the host's world and destroy our roster.
-	if (getServerOwner() || !_host_save_progress || !getCoopStatic() || connectionTCP::saveID == 0)
+	if (getServerOwner() || !getCoopStatic() || connectionTCP::saveID == 0)
 	{
 		return;
 	}
@@ -970,8 +1287,12 @@ void connectionTCP::pushProgressToHostSilently()
 		return;
 	}
 
-	std::string filename = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+	std::string filename = clientBlobKey(_game->getCoopMod()->getHostName());
 	_game->getSavedGame()->saveCoopToMemory(filename, _game->getMod(), filename);
+	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		eraseStaleBlobEntries(coopFilesClient, "client_", _game->getCoopMod()->getHostName(), filename);
+	}
 
 	Json::Value obj;
 	obj["state"] = "SEND_FILE_HOST_TRUE_SAVE_PROGRESS";
@@ -999,7 +1320,7 @@ void connectionTCP::syncOwnWorldGuestCraft(int coopBaseId, const std::map<std::s
 	// to upload its live (host) world as the client blob - the exact corruption
 	// Fix A prevents. We only edit the in-memory own-world blob, which is all the
 	// mission-end reload needs.
-	if (getServerOwner() || !_host_save_progress || !getCoopStatic() || connectionTCP::saveID == 0)
+	if (getServerOwner() || !getCoopStatic() || connectionTCP::saveID == 0)
 	{
 		return;
 	}
@@ -1008,7 +1329,7 @@ void connectionTCP::syncOwnWorldGuestCraft(int coopBaseId, const std::map<std::s
 		return;
 	}
 
-	std::string filename = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+	std::string filename = clientBlobKey(_game->getCoopMod()->getHostName());
 	if (!hasCoopFile(filename))
 	{
 		return;
@@ -1060,6 +1381,47 @@ void connectionTCP::resetTransferSessionState()
 	_pendingIncomingTransfers.clear();
 	_seenTransferPacketIds.clear();
 	_transferredAwaySoldierIds.clear();
+
+	// PRD-06 C5: a different world is being loaded - abort any armed deferred
+	// host save so a late client blob cannot rewrite the (now stale) named save.
+	if (!session.pendingHostSaveName.empty())
+	{
+		Log(LOG_INFO) << "[coop] world switch aborts armed deferred host save (" << session.pendingHostSaveName << ")";
+		session.pendingHostSaveName.clear();
+	}
+
+}
+
+void connectionTCP::writePendingHostSave()
+{
+
+	if (session.pendingHostSaveName.empty())
+	{
+		return;
+	}
+
+	// A battle started (or the save vanished) since the request: the live world
+	// is no longer the one the save captured - disarm without writing.
+	if (!_game->getSavedGame() || _game->getSavedGame()->getSavedBattle())
+	{
+		session.pendingHostSaveName.clear();
+		return;
+	}
+
+	try
+	{
+		// same atomic dance as SaveGameState: backup, then rename
+		std::string backup = session.pendingHostSaveName + ".bak";
+		_game->getSavedGame()->save(backup, _game->getMod());
+		CrossPlatform::moveFile(Options::getMasterUserFolder() + backup,
+								Options::getMasterUserFolder() + session.pendingHostSaveName);
+	}
+	catch (const std::exception& e)
+	{
+		Log(LOG_ERROR) << "[coop] deferred host save write failed: " << e.what();
+	}
+
+	session.clearDeferredSave();
 
 }
 
@@ -1298,11 +1660,23 @@ void connectionTCP::updateCoopTask()
 		if (allow_cutscene == true)
 		{
 			// Make sure it calls disconnectTCP, otherwise it may get stuck.
-			if (server_owner == true)
+			if (getServerOwner() == true)
 			{
-				_game->pushState(new CoopState(20));
+				// campaign flow: no "... has left the server" popup - the
+				// waiting lobby / freeze dialog handles real drops and a
+				// refused joiner warrants no notification at all (D5). The
+				// disconnect still has to run (CoopState(20)'s constructor
+				// used to do it); its cleanup pushes the freeze dialog.
+				if (connectionTCP::session.lobbyMode == 0)
+				{
+					_game->pushState(new CoopState(20));
+				}
+				else
+				{
+					_game->getCoopMod()->disconnectTCP();
+				}
 			}
-			else if (server_owner == false)
+			else if (getServerOwner() == false)
 			{
 				_game->pushState(new CoopState(21));
 			}
@@ -1725,11 +2099,11 @@ void resetCoopState(bool isHost)
 	mapData.clear();
 
 	onTcpHost = isHost;
-	server_owner = isHost;
+	connectionTCP::session.role = isHost ? CoopRole::Host : CoopRole::Client;
 	onConnect = -1;
 	connectionTCP::no_bases = false;
 	connectionTCP::isCoopBaseLoading = false;
-	connectionTCP::isCoopSessionLocked = false;
+	connectionTCP::session.sessionLocked = false;
 	connectionTCP::isPlayerReady = false;
 	connectionTCP::isPlayersReady = false;
 	connectionTCP::LobbyFileStatus = -1;
@@ -2103,7 +2477,9 @@ void connectionTCP::startTCPHost()
 	recvBuffer.reserve(4096);
 
 	onConnect = 1;
-	server_owner = true;
+	// thread-side role mirror (pre-struct behavior kept; the main-thread
+	// hosting path also sets this via setServerOwner)
+	session.role = CoopRole::Host;
 
 	for (;;)
 	{
@@ -2278,14 +2654,17 @@ void connectionTCP::startTCPHost()
 	SDLNet_FreeSocketSet(socketSet);
 	SDLNet_Quit();
 
-	server_owner = false;
+	// thread-side role clear on host-thread exit (pre-struct behavior kept)
+	session.role = CoopRole::None;
 	onConnect = -1;
 	return;
 }
 
 void connectionTCP::initProfile(bool clientInBattle, bool inBattle)
 {
-	if (_game->getCoopMod()->getServerOwner() == false && (connectionTCP::_host_save_progress == true || connectionTCP::no_bases == true))
+	// campaign flow: sessions are lobby-gated up front - no post-join lobby
+	// re-entry (F2/F3). Only the legacy new-battle path reopens it here.
+	if (_game->getCoopMod()->getServerOwner() == false && connectionTCP::session.lobbyMode == 0)
 	{
 		_game->pushState(new LobbyMenu);
 	}
@@ -2344,6 +2723,30 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 	}
 
+	// refused by the campaign roster gate (flow-redesign F3)
+	if (stateString == "lobby_join_refused")
+	{
+
+		connectionTCP::joinRefusalReason = obj.get("reason", "").asString();
+
+		disconnectTCP();
+
+		// drop the "Connecting..." dialog left from the join attempt so
+		// dismissing the refusal leaves no stray dialog behind
+		if (!_game->getStates().empty())
+		{
+			CoopState* topDialog = dynamic_cast<CoopState*>(_game->getStates().back());
+			if (topDialog && topDialog->getStateCode() == 15)
+			{
+				_game->popState();
+			}
+		}
+		connectionTCP::forceCloseCoopStateMenu = true;
+
+		_game->pushState(new CoopState(63));
+
+	}
+
 	if (stateString == "tcp_password")
 	{
 
@@ -2359,7 +2762,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 	if (stateString == "lobby_ready")
 	{
 
-		connectionTCP::isCoopSessionLocked = true;
+		connectionTCP::session.campaignStarted();
 
 	}
 
@@ -2384,7 +2787,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true)
 		{
-			connectionTCP::isCoopSessionLocked = true;
+			connectionTCP::session.campaignStarted();
 		}
 
 	}
@@ -2400,8 +2803,121 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 	if (stateString == "change_team")
 	{
 
-		int gamemode = obj["gamemode"].asInt();
-		connectionTCP::_coopGamemode = gamemode;
+		// teams are locked once the campaign starts (flow-redesign D3)
+		if (connectionTCP::session.sessionLocked == false)
+		{
+			int gamemode = obj["gamemode"].asInt();
+			connectionTCP::_coopGamemode = gamemode;
+		}
+
+	}
+
+	// --- campaign flow redesign ------------------------------------------
+	// Host clicked START CAMPAIGN: build this player's own world with the
+	// host's difficulty (D2; ironman stays host-only) and begin base
+	// placement. The lobby is wiped by setState.
+	if (stateString == "campaign_start" && getServerOwner() == false)
+	{
+
+		int difficulty = obj["difficulty"].asInt();
+		connectionTCP::_coopGamemode = obj["gamemode"].asInt();
+		connectionTCP::saveID = obj["saveID"].asInt64();
+		connectionTCP::session.campaignStarted();
+		connectionTCP::session.lobbyMode = 1;
+
+		std::vector<std::string> players;
+		for (const auto& p : obj["players"])
+		{
+			players.push_back(p.asString());
+		}
+
+		SavedGame* save = _game->getMod()->newSave((GameDifficulty)difficulty);
+		save->setDifficulty((GameDifficulty)difficulty);
+		save->setCoopSave(true);
+		save->setCoopPlayers(players);
+		_game->setSavedGame(save);
+
+		connectionTCP::session.markLobbyClosed();
+
+		GeoscapeState* gs = new GeoscapeState;
+		_game->setState(gs);
+		gs->init();
+
+		beginInitialBasePlacement(_game, gs, _game->getSavedGame()->getBases()->back());
+
+	}
+
+	// Host clicked RESUME CAMPAIGN and we have a stored world: fetch it
+	// (same wire flow as the classic Profile resume) (F3)
+	if (stateString == "campaign_resume" && getServerOwner() == false)
+	{
+
+		_game->pushState(new CoopState(COOP_DLG_CLIENT_LOAD_WAIT));
+
+		Json::Value root;
+		root["state"] = "request_load_progress";
+		sendTCPPacketData(root.toStyledString());
+
+	}
+
+	// PRD-11 C13: the host is busy streaming another transfer. Signal the
+	// load-wait dialog to retry (it schedules a ~2s-spaced retry, bounded).
+	if (stateString == "load_progress_busy" && getServerOwner() == false)
+	{
+		connectionTCP::loadProgressBusy = true;
+	}
+
+	// The host began/resumed the campaign: drop the waiting dialog (D5)
+	if (stateString == "campaign_begun" && getServerOwner() == false)
+	{
+
+		connectionTCP::session.signalCampaignBegun();
+		connectionTCP::session.sessionLive();
+
+	}
+
+	// A resuming player finished loading its world (F3). For a battle save
+	// the geoscape ack triggers phase two: the battle stream.
+	if (stateString == "resume_ack")
+	{
+
+		// PRD-11 C8: only stream the battle to a client that was actually served
+		// a resume world blob. A registered-but-no-blob client is routed through
+		// fresh base building and acks too (BaseNameState); streaming the old
+		// battle into its freshly built world would corrupt it. Such an acker is
+		// absent from resumeBattleEligible, so it falls through to the plain
+		// campaign-resume ack.
+		std::string acker = _game->getCoopMod()->getCurrentClientName();
+		bool battleEligible = connectionTCP::session.resumeBattleEligible.count(acker) > 0;
+
+		if (connectionTCP::session.resumeBattlePending && battleEligible)
+		{
+			connectionTCP::session.resumeBattlePending = false;
+			connectionTCP::session.resumeBattleEligible.clear();
+
+			Json::Value root;
+			root["state"] = "campaign_resume_battle";
+			sendTCPPacketData(root.toStyledString());
+		}
+		else
+		{
+			connectionTCP::session.resumeAck = true;
+		}
+
+	}
+
+	// Phase two of a battle-save resume: fetch the battle from the host
+	// (same wire flow the legacy lobby used for a battle-hosting session)
+	if (stateString == "campaign_resume_battle" && getServerOwner() == false)
+	{
+
+		_game->getCoopMod()->inventory_battle_window = false;
+
+		_game->pushState(new CoopState(1));
+
+		Json::Value root;
+		root["state"] = "SEND_FILE_CLIENT_SAVE";
+		sendTCPPacketData(root.toStyledString());
 
 	}
 
@@ -2890,8 +3406,19 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 	if (stateString == "server_full")
 	{
 
-		onConnect = -1;
-		_game->pushState(new CoopState(444));
+		// PRD-11: server_full is a host->client refusal. onConnect = -1 is the
+		// host listen thread's exit condition, so a client that spoofs this
+		// message could stop the host's thread. Only act on it as a client.
+		if (connectionTCP::session.role == CoopRole::Client)
+		{
+			onConnect = -1;
+			_game->pushState(new CoopState(444));
+		}
+		else
+		{
+			Log(LOG_WARNING) << "[coop] ignoring server_full: not a client (role="
+				<< (connectionTCP::session.role == CoopRole::Host ? "Host" : "None") << ")";
+		}
 	}
 
 	if (stateString == "chat_message")
@@ -2917,25 +3444,51 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 	if (stateString == "request_load_progress")
 	{
 
-		if (_game->getSavedGame())
+		if (_game->getSavedGame() && !sendFileClient)
 		{
 
-			bool found = false;
+			// battle live: after the geoscape world ack, stream the battle
+			// (F3 battle-save resume + F4 mid-battle rejoin share this)
+			connectionTCP::session.resumeBattlePending = (_game->getSavedGame()->getSavedBattle() != nullptr);
 
-			std::string filename = "host_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getCurrentClientName() + ".data";
-			std::string filepath = Options::getMasterUserFolder() + filename;
-
-			if (OpenXcom::CrossPlatform::fileExists(filepath))
+			// PRD-09 C12: F3 battle-save resume in a fresh process. Unlike the
+			// live mission-start path (SEND_FILE_CLIENT_TRUE stashes
+			// coop_geoscape_return before dispatching the mission), nothing
+			// regenerates that snapshot on resume - so the server owner's
+			// mission-end restore would keep the peer-derived battle world as its
+			// campaign. Stash the loaded world's geoscape now, while
+			// getServerOwner() is true (so it lands in coopFilesHost where the
+			// restore reads it). Detach the battle first: coop_geoscape_return
+			// must be a PURE geoscape - the restore reloads it as the continuation
+			// world and re-entering it must not resurrect the just-finished battle.
+			if (connectionTCP::session.resumeBattlePending && getServerOwner() == true && _game->getCoopMod()->getCoopCampaign() == true)
 			{
-				found = true;
+				SavedBattleGame* keepBattle = _game->getSavedGame()->detachBattleGame();
+				_game->getSavedGame()->saveCoopToMemory("coop_geoscape_return", _game->getMod(), "coop_geoscape_return");
+				_game->getSavedGame()->reattachBattleGame(keepBattle);
+				Log(LOG_INFO) << "[coop] F3 battle resume: stashed geoscape-only coop_geoscape_return for mission-end restore";
 			}
 
-			if (found == false)
+			std::string filename = hostBlobKey(_game->getCoopMod()->getCurrentClientName());
+
+			bool blobFound = false;
+			{
+				std::lock_guard<std::mutex> lock(coopFilesMutex);
+				auto it = coopFilesHost.find(filename);
+				if (it != coopFilesHost.end() && !it->second.empty())
+				{
+					// found! snapshot the blob for the streamer thread
+					sendProgressLoadBlob = it->second;
+					blobFound = true;
+				}
+			}
+
+			if (!blobFound)
 			{
 
-				// not found, create new save game
-				Json::Value root;
-				root["state"] = "new_game";
+				// registered player without a stored world: fresh world with
+				// the campaign's difficulty + base building (D2/D6)
+				Json::Value root = buildCampaignStartPacket(_game->getSavedGame());
 
 				sendTCPPacketData(root.toStyledString());
 
@@ -2943,11 +3496,27 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 			else
 			{
 
-				// found!
+				// PRD-11 C8: this client is being served a real resume world;
+				// mark it eligible for the follow-up battle stream. The no-blob
+				// campaign_start branch above deliberately does NOT.
+				connectionTCP::session.resumeBattleEligible.insert(
+					_game->getCoopMod()->getCurrentClientName());
+
 				sendFileClient = true;
-				sendProgressLoadFileToClient = filepath;
+				sendProgressLoadFileToClient = filename;
 
 			}
+
+		}
+		else if (_game->getSavedGame() && sendFileClient)
+		{
+
+			// PRD-11 C13: the streamer is busy with another transfer. Never drop
+			// the request silently (the client's load-wait dialog has no timeout);
+			// tell it to retry.
+			Json::Value busy;
+			busy["state"] = "load_progress_busy";
+			sendTCPPacketData(busy.toStyledString());
 
 		}
 
@@ -6341,13 +6910,6 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 					_isActivePlayerSync = true;
 
-					// Auto save before (only HOST)
-					SavedGame* newsave = new SavedGame(*_game->getSavedGame());
-
-					newsave->setName("coop_mission_2");
-
-					newsave->save("coop_mission_2.sav", _game->getMod());
-
 					_battleInit = false;
 					_isActiveAISync = true;
 
@@ -6387,10 +6949,15 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		// Closing save progress popup - only if one is actually open (silent
 		// background pushes don't show the dialog; popping the screen under
-		// it would tear down the geoscape).
-		if (!_game->getStates().empty() && dynamic_cast<CoopState*>(_game->getStates().back()))
+		// it would tear down the geoscape). The campaign wait dialogs
+		// (60/62/64/65) manage their own lifetime - never pop those.
+		if (!_game->getStates().empty())
 		{
-			_game->popState();
+			CoopState* top = dynamic_cast<CoopState*>(_game->getStates().back());
+			if (top && !top->isCampaignWaitDialog())
+			{
+				_game->popState();
+			}
 		}
 
 	}
@@ -6407,7 +6974,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 	}
 
-	if (stateString == "close_load_progress" && server_owner == true)
+	if (stateString == "close_load_progress" && getServerOwner() == true)
 	{
 
 		Json::Value root;
@@ -6424,16 +6991,30 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		sendTCPPacketData(jsonData333);
 
 		// Closing save progress popup - only if one is actually open (silent
-		// background pushes don't show the dialog).
-		if (!_game->getStates().empty() && dynamic_cast<CoopState*>(_game->getStates().back()))
+		// background pushes don't show the dialog). The campaign wait dialogs
+		// (60/62/64/65) manage their own lifetime - never pop those.
+		if (!_game->getStates().empty())
 		{
-			_game->popState();
+			CoopState* top = dynamic_cast<CoopState*>(_game->getStates().back());
+			if (top && !top->isCampaignWaitDialog())
+			{
+				_game->popState();
+			}
 		}
 
 		// WRITE THE FILE RECEIVED FROM THE CLIENT TO THE HOST
 		if (_game->getSavedGame())
 		{
+			// Install the freshest client blob. On validation failure (PRD-07)
+			// the store keeps the last-good blob, so the write below stays safe.
 			writeHostMapSaveProgressFile();
+
+			// PRD-06/E1: the SaveGameState funnel deferred its write to here, so
+			// this is the single emit of the host .sav for this save cycle - and
+			// it embeds the client world that just arrived. (No longer gated on
+			// the blob being fresh: even a rejected blob leaves a valid last-good
+			// one to embed, and the user asked for a save.)
+			writePendingHostSave();
 		}
 
 	}
@@ -6551,16 +7132,55 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 			return;
 		}
 
-		// HostSaveProgress
-		bool host_save_progress = obj["host_save_progress"].asBool();
-		connectionTCP::_host_save_progress = host_save_progress;
-
 		long long saveID = obj["saveID"].asInt64();
 		connectionTCP::saveID = saveID;
 
 		tcpPlayerName = obj.get("playername", tcpPlayerName).asString();
 
-		_game->pushState(new Profile);
+		// campaign lobby (new or resume): sit in the lobby until the host
+		// clicks START/RESUME CAMPAIGN (flow-redesign F2/F3). A mid-session
+		// rejoin (F4) fetches its world straight away; otherwise the classic
+		// path (Profile -> request_load_progress).
+		bool campaignStarted = obj.get("campaign_started", true).asBool();
+		bool rejoin = obj.get("rejoin", false).asBool();
+
+		// Pop the "Connecting..." wait dialog (CoopState 15) NOW, before pushing
+		// the lobby/load dialog over it. forceCloseCoopStateMenu can't reach it
+		// once buried (a non-top state gets no think() tick, and LobbyMenu's ctor
+		// clears the flag anyway), so it would linger and resurface as a stale
+		// "Connecting..." window when the client later leaves the lobby.
+		while (!_game->getStates().empty())
+		{
+			CoopState* connecting = dynamic_cast<CoopState*>(_game->getStates().back());
+			if (connecting && connecting->getStateCode() == 15)
+				_game->popState();
+			else
+				break;
+		}
+
+		if (!campaignStarted)
+		{
+			connectionTCP::session.lobbyMode = obj.get("lobby_mode", 1).asInt();
+			connectionTCP::forceCloseCoopStateMenu = true;
+			connectionTCP::forceClosePasswordCheckMenu = true;
+			_game->pushState(new LobbyMenu());
+		}
+		else if (rejoin)
+		{
+			connectionTCP::session.lobbyMode = obj.get("lobby_mode", 0).asInt();
+			connectionTCP::forceCloseCoopStateMenu = true;
+			connectionTCP::forceClosePasswordCheckMenu = true;
+
+			_game->pushState(new CoopState(COOP_DLG_CLIENT_LOAD_WAIT));
+
+			Json::Value req;
+			req["state"] = "request_load_progress";
+			sendTCPPacketData(req.toStyledString());
+		}
+		else
+		{
+			_game->pushState(new Profile);
+		}
 
 	}
 
@@ -6645,6 +7265,59 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		std::string playername = obj.get("playername", "defaultState").asString();
 		std::string servername = obj.get("servername", "defaultState").asString();
+
+		// A joiner may never take a name already in use in this session -
+		// the host's own name, or any currently attached client's. (The
+		// host's name passes the roster check below and would collapse both
+		// players into one identity; a DROPPED client's name stays available
+		// on purpose - that is how a rejoin identifies itself. With today's
+		// single-client transport the attached-client case is preempted by
+		// the server-full close, but the check is written for N clients.)
+		bool nameInUse = (playername == _game->getCoopMod()->getHostName());
+		if (connectionTCP::session.clientInLobby
+			&& playername == _game->getCoopMod()->getCurrentClientName())
+		{
+			nameInUse = true;
+		}
+		if (nameInUse)
+		{
+			Json::Value refuse;
+			refuse["state"] = "lobby_join_refused";
+			refuse["reason"] = "That player name is already in use.";
+			sendTCPPacketData(refuse.toStyledString());
+			return;
+		}
+
+		// Campaign roster gate (flow-redesign D4/D6): once the player list is
+		// locked (non-empty), only registered names may connect - covers the
+		// resume lobby, mid-session rejoin, and strangers joining a running
+		// campaign. An empty list = pre-START lobby, anyone may join.
+		if (_game->getCoopMod()->getCoopCampaign() == true
+			&& _game->getSavedGame()
+			&& _game->getSavedGame()->isCoopSave())
+		{
+			const auto& registered = _game->getSavedGame()->getCoopPlayers();
+			if (!registered.empty())
+			{
+				bool known = false;
+				for (const auto& p : registered)
+				{
+					if (p == playername)
+					{
+						known = true;
+					}
+				}
+				if (!known)
+				{
+					Json::Value refuse;
+					refuse["state"] = "lobby_join_refused";
+					refuse["reason"] = "You are not a player in this campaign.";
+					sendTCPPacketData(refuse.toStyledString());
+					return;
+				}
+			}
+		}
+
 		tcpPlayerName = playername;
 		tcpServerName = servername;
 
@@ -6662,9 +7335,6 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 			index++;
 		}
-
-		// HostSaveProgress
-		connectionTCP::_host_save_progress = Options::HostSaveProgress;
 
 		// password
 		if (connectionTCP::isPasswordRequired == true && !OpenXcom::isConnectionUDPActive())
@@ -6686,11 +7356,26 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		}
 
-		if (connectionTCP::_host_save_progress == true && _game->getCoopMod()->getCoopCampaign() == true)
+		// past every gate: a real client is now attached to the session
+		connectionTCP::session.clientAttached();
+
+		if (_game->getCoopMod()->getCoopCampaign() == true)
 		{
 			root["state"] = "COOP_READY_SAVE_PROGRESS";
-			root["host_save_progress"] = _host_save_progress;
+			// Kept on the wire for older clients; host-save authority is the only mode.
+			root["host_save_progress"] = true;
+			// campaign lobbies (new or resume): the client joins the lobby
+			// instead of requesting a world (flow-redesign F2/F3). A live
+			// session (lobby closed) = mid-session rejoin: fetch directly.
+			root["campaign_started"] = (connectionTCP::session.lobbyMode == 0 || connectionTCP::session.lobbyClosed == true);
+			root["rejoin"] = (connectionTCP::session.lobbyMode != 0 && connectionTCP::session.lobbyClosed == true);
+			root["lobby_mode"] = connectionTCP::session.lobbyMode;
 
+			// Handshake fallback only: a resume carries the loaded saveID (nonzero,
+			// so skipped here) and a new campaign re-mints in startCampaign and
+			// re-broadcasts via campaign_start (which the client adopts). This
+			// mint just guarantees the join reply never sends 0 when a client
+			// connects before START CAMPAIGN is clicked.
 			if (connectionTCP::saveID == 0)
 			{
 				connectionTCP::saveID = getDateTimeCoop();
@@ -6709,7 +7394,11 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		sendTCPPacketData(root.toStyledString());
 
-		_game->pushState(new Profile);
+		// campaign lobbies are host-driven: no Profile screen (F2/F3)
+		if (connectionTCP::session.lobbyMode == 0)
+		{
+			_game->pushState(new Profile);
+		}
 
 	}
 
@@ -6755,11 +7444,11 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		root["craft_count"] = craft_count;
 
 		// is session locked?
-		root["isCoopSessionLocked"] = connectionTCP::isCoopSessionLocked;
+		root["isCoopSessionLocked"] = connectionTCP::session.sessionLocked;
 		root["isPlayerReady"] = connectionTCP::isPlayerReady;
-		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true && connectionTCP::isCoopSessionLocked == false)
+		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true && connectionTCP::session.sessionLocked == false)
 		{
-			connectionTCP::isCoopSessionLocked = true;
+			connectionTCP::session.campaignStarted();
 		}
 
 		// research option
@@ -6840,12 +7529,14 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 		onceTime = true;
 
-		// is session locked?
-		connectionTCP::isCoopSessionLocked = obj["isCoopSessionLocked"].asBool();
+		// is session locked? (value-carrying: mirror the host's flag from the
+		// wire, then lock if both are ready) - the raw mirror stays; the derived
+		// lock funnels through the transition.
+		connectionTCP::session.sessionLocked = obj["isCoopSessionLocked"].asBool();
 		connectionTCP::isPlayersReady = obj["isPlayerReady"].asBool();
-		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true && connectionTCP::isCoopSessionLocked == false)
+		if (connectionTCP::isPlayerReady == true && connectionTCP::isPlayersReady == true && connectionTCP::session.sessionLocked == false)
 		{
-			connectionTCP::isCoopSessionLocked = true;
+			connectionTCP::session.campaignStarted();
 		}
 
 		// set current gamemode
@@ -6870,19 +7561,10 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		if (host_coop_campaign != client_coop_campaign)
 		{
 
-			// if campaign
-			if (host_coop_campaign == true)
-			{
-
-				if (connectionTCP::_host_save_progress == false)
-				{
-					connectionTCP::no_bases = true;
-					_game->pushState(new GeoscapeState());
-				}
-
-			}
+			// if campaign: nothing to do - the client's world comes from the
+			// host (new_game or streamed progress)
 			// if new battle
-			else
+			if (host_coop_campaign == false)
 			{
 				_game->pushState(new CoopState(3000));
 
@@ -7673,13 +8355,14 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 			sendBaseFile();
 
-			// Save the geospace file so the player can return to it later
-			if (_game->getCoopMod()->getCoopCampaign() == true && (connectionTCP::_host_save_progress == false || _game->getCoopMod()->getServerOwner() == true))
-			{
-				_game->getSavedGame()->setName("coop_geoscape_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName());
-				_game->getSavedGame()->save("coop_geoscape_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".sav", _game->getMod());
-			}
+		}
 
+		// Stash the geoscape world in memory so the player can return to it
+		// after the mission (never written to disk). Outside the target check
+		// so the mission-end reload always has a snapshot.
+		if (_game->getSavedGame() && _game->getCoopMod()->getCoopCampaign() == true)
+		{
+			_game->getSavedGame()->saveCoopToMemory("coop_geoscape_return", _game->getMod(), "coop_geoscape_return");
 		}
 
 		CoopState* coopWindow = new CoopState(1);
@@ -7857,7 +8540,7 @@ void connectionTCP::setCoopSession(bool session)
 
 void connectionTCP::setServerOwner(bool owner)
 {
-	server_owner = owner;
+	session.setRole(owner ? CoopRole::Host : CoopRole::None);
 }
 
 void connectionTCP::setCoopCampaign(bool coop)
@@ -7906,13 +8589,16 @@ void connectionTCP::writeHostMapFile2()
 	if (mapData.empty())
 		return;
 
-	if (connectionTCP::getServerOwner() == true)
 	{
-		connectionTCP::coopFilesHost["baseclient"] = std::move(mapData);
-	}
-	else
-	{
-		connectionTCP::coopFilesClient["baseclient"] = std::move(mapData);
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		if (connectionTCP::getServerOwner() == true)
+		{
+			connectionTCP::coopFilesHost["baseclient"] = std::move(mapData);
+		}
+		else
+		{
+			connectionTCP::coopFilesClient["baseclient"] = std::move(mapData);
+		}
 	}
 
 	// the map data must be reset for the next use (fix)
@@ -8082,9 +8768,13 @@ void connectionTCP::sendSaveProgressFile()
 		_game->pushState(coopWindow);
 
 		// saving files
-		std::string filename = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+		std::string filename = clientBlobKey(_game->getCoopMod()->getHostName());
 
 		_game->getSavedGame()->saveCoopToMemory(filename, _game->getMod(), filename);
+		{
+			std::lock_guard<std::mutex> lock(coopFilesMutex);
+			eraseStaleBlobEntries(coopFilesClient, "client_", _game->getCoopMod()->getHostName(), filename);
+		}
 
 		_game->getCoopMod()->load_state = "Saving";
 
@@ -8446,7 +9136,7 @@ void connectionTCP::generateCraftSoldiers()
 
 bool connectionTCP::getServerOwner()
 {
-	return server_owner;
+	return session.role == CoopRole::Host;
 }
 
 void connectionTCP::setPathLock(int lock)
@@ -8697,6 +9387,8 @@ void connectionTCP::hostTCPServer(std::string servername, std::string str_port)
 		_hostThread.join();
 	}
 
+	session.beginHosting();
+
 	_hostStop = false;
 	 _hostThread = std::thread(&connectionTCP::startTCPHost, this);
 
@@ -8735,6 +9427,8 @@ void connectionTCP::connectTCPServer(std::string ipaddress, std::string str_port
 		_clientStop = true;
 		_clientThread.join();
 	}
+
+	session.beginJoining();
 
 	_clientStop = false;
 
@@ -8860,7 +9554,6 @@ void connectionTCP::disconnectTCP(bool isMain)
 		peerTimeSpeedId = "";
 		peerFocusScreen = -1;
 		connectionTCP::lobby_timer = -1;
-		connectionTCP::isCoopSessionLocked = false;
 		connectionTCP::isPlayerReady = false;
 		connectionTCP::isPlayersReady = false;
 
@@ -8877,19 +9570,56 @@ void connectionTCP::disconnectTCP(bool isMain)
 
 		deleteAllCoopBases();
 
+		// Capture the machine role ONCE for this teardown - handlers used to
+		// mutate server_owner mid-flight and make the cleanup misclassify the
+		// machine (the disconnect->cancel bug family).
+		const bool teardownAsHost = (session.role == CoopRole::Host);
+
 		// both
-		if ((connectionTCP::no_bases == true || (connectionTCP::_host_save_progress == true && server_owner == false)) && !isMain && connectionTCP::_coopCampaign == true)
+		if ((connectionTCP::no_bases == true || !teardownAsHost) && !isMain && connectionTCP::_coopCampaign == true)
 		{
 			_game->setState(new MainMenuState);
 		}
 
 		// host
-		if (server_owner == true && onConnect == -2)
+		if (teardownAsHost && onConnect == -2)
 		{
 
 			onConnect = 1;
 
-			if (connectionTCP::isLobbyMenuClosed == true)
+			if (connectionTCP::session.lobbyMode != 0 && connectionTCP::session.lobbyClosed == true)
+			{
+				// mid-session client drop: freeze until they reconnect (D5).
+				// The dialog sits over the geoscape/battlescape, pausing it.
+				// Don't stack a second dialog when a campaign wait dialog that
+				// already covers "wait for the player to come back" is present
+				// ANYWHERE in the stack, not just on top. A resume-ack wait (62)
+				// already shows RESUME once resumeAck arrives, so it covers the
+				// freeze dialog's job - stacking a 64 over a buried 62 produces
+				// two RESUME dialogs and a double campaign_begun broadcast (C9).
+				bool waitDialogPresent = false;
+				for (State* st : _game->getStates())
+				{
+					CoopState* cs = dynamic_cast<CoopState*>(st);
+					if (cs && (cs->getStateCode() == COOP_DLG_FREEZE
+							|| cs->getStateCode() == COOP_DLG_RESUME_ACK_WAIT))
+					{
+						waitDialogPresent = true;
+						break;
+					}
+				}
+				if (!waitDialogPresent)
+				{
+					connectionTCP::session.freeze();
+					_game->pushState(new CoopState(COOP_DLG_FREEZE));
+				}
+				else
+				{
+					Log(LOG_INFO) << "[coop] freeze dialog suppressed: a campaign "
+						"wait dialog (freeze/resume-ack) is already on the stack";
+				}
+			}
+			else if (connectionTCP::session.lobbyClosed == true)
 			{
 				_game->pushState(new LobbyMenu);
 			}
@@ -8900,7 +9630,13 @@ void connectionTCP::disconnectTCP(bool isMain)
 		{
 
 			onConnect = -1;
-			connectionTCP::_host_save_progress = false;
+
+			// The client's world came from the host and is re-streamed on the
+			// next join; drop the session's blobs.
+			{
+				std::lock_guard<std::mutex> lock(coopFilesMutex);
+				connectionTCP::coopFilesClient.clear();
+			}
 
 			if (_chatMenu)
 			{
@@ -8912,6 +9648,18 @@ void connectionTCP::disconnectTCP(bool isMain)
 				setChatMenu(nullptr);
 			}
 
+		}
+
+		// Session-state resets: exactly two paths (see CoopSession). The host
+		// keeps its campaign/lobby context across a peer drop (D5); a client's
+		// session is over. Never clear individual fields here.
+		if (teardownAsHost)
+		{
+			connectionTCP::session.onClientDrop();
+		}
+		else
+		{
+			connectionTCP::session.resetSession();
 		}
 
 		connectionTCP::no_bases = false;
@@ -9005,25 +9753,36 @@ void connectionTCP::writeHostMapFile()
 
 		std::string filename = "battleclient";
 
-		connectionTCP::coopFilesHost[filename] = std::move(mapData);
+		{
+			std::lock_guard<std::mutex> lock(coopFilesMutex);
+			connectionTCP::coopFilesHost[filename] = std::move(mapData);
+		}
 
 		// RECEIVE CLIENT DATA
 		SavedGame* client_save = new SavedGame();
 
 		client_save->loadCoopSaveFromMemory(filename, _game->getMod(), _game->getLanguage(), filename);
 
-		if (client_save && connectionTCP::_host_save_progress == true && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
+		if (client_save && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == true)
 		{
 
-			std::string filename = "host_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getCurrentClientName() + ".data";
+			std::string filename = hostBlobKey(_game->getCoopMod()->getCurrentClientName());
 
-			client_save->save(filename, _game->getMod());
+			// served copy lives in memory only; the host .sav embed persists it
+			client_save->saveCoopToMemory(filename, _game->getMod(), filename);
+			{
+				std::lock_guard<std::mutex> lock(coopFilesMutex);
+				eraseStaleBlobEntries(coopFilesHost, "host_", _game->getCoopMod()->getCurrentClientName(), filename);
+			}
 
 		}
+
+		delete client_save;
 
 	}
 	else
 	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
 		connectionTCP::coopFilesClient["battleclient"] = std::move(mapData);
 	}
 
@@ -9031,18 +9790,27 @@ void connectionTCP::writeHostMapFile()
 	mapData = "";
 }
 
-void connectionTCP::writeHostMapSaveProgressFile()
+bool connectionTCP::writeHostMapSaveProgressFile()
 {
 
-	std::string filename = "host_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getCurrentClientName() + ".data";
+	std::string filename = hostBlobKey(_game->getCoopMod()->getCurrentClientName());
 
 	if (mapData.empty())
-		return;
+		return false;
 
-	connectionTCP::coopFilesHost[filename] = std::move(mapData);
+	// PRD-07 C10: validate the incoming blob BEFORE it touches the store. The
+	// previous order installed (and pruned siblings) first, so a blob that
+	// failed validation had already displaced the last-good one. Here we parse
+	// a throwaway COPY under a scratch key, leaving mapData and the real entry
+	// untouched; only a blob that passes every check is installed.
+	static const std::string scratchKey = "__validate_save_progress__";
+	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		connectionTCP::coopFilesHost[scratchKey] = mapData; // copy, not move
+	}
 
 	SavedGame* coopFile = new SavedGame();
-	coopFile->loadCoopSaveFromMemory(filename, _game->getMod(), _game->getLanguage(), filename);
+	coopFile->loadCoopSaveFromMemory(scratchKey, _game->getMod(), _game->getLanguage(), scratchKey);
 
 	bool error = false;
 	bool found = false;
@@ -9072,33 +9840,65 @@ void connectionTCP::writeHostMapSaveProgressFile()
 		error = true;
 	}
 
-	if (error == false && coopFile && found == true)
+	bool stored = (error == false && coopFile && found == true);
+
+	std::string failReason;
+	if (!stored)
 	{
-
-		coopFile->save(filename, _game->getMod());
-
+		failReason = (coopFile == nullptr) ? "parse failed"
+			: error ? "base with empty name or null coords"
+			: "no non-coop (own) base present";
 	}
-	else
-	{
 
+	delete coopFile;
+
+	// drop the scratch entry either way - it never becomes the served blob.
+	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		connectionTCP::coopFilesHost.erase(scratchKey);
+	}
+
+	if (!stored)
+	{
+		// Failure path: leave the store EXACTLY as it was (the last-good blob
+		// stays served + embeddable) and surface the error popup.
+		Log(LOG_WARNING) << "[coop] rejected client progress blob from '"
+						  << _game->getCoopMod()->getCurrentClientName() << "': " << failReason
+						  << "; keeping last-good blob";
 		_game->pushState(new CoopState(994));
 
+		// the map data must be reset for the next use (fix)
+		mapData = "";
+		return false;
+	}
+
+	// Success: install the validated blob + prune stale siblings. The served
+	// copy lives in memory only; persistence is the blob embedded in the host .sav.
+	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		connectionTCP::coopFilesHost[filename] = std::move(mapData);
+		eraseStaleBlobEntries(coopFilesHost, "host_", _game->getCoopMod()->getCurrentClientName(), filename);
 	}
 
 	// the map data must be reset for the next use (fix)
 	mapData = "";
 
+	return true;
 }
 
 void connectionTCP::writeHostMapLoadProgressFile()
 {
 
-	std::string filename = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
+	std::string filename = clientBlobKey(_game->getCoopMod()->getHostName());
 
 	if (mapData.empty())
 		return;
 
-	connectionTCP::coopFilesClient[filename] = std::move(mapData);
+	{
+		std::lock_guard<std::mutex> lock(coopFilesMutex);
+		connectionTCP::coopFilesClient[filename] = std::move(mapData);
+		eraseStaleBlobEntries(coopFilesClient, "client_", _game->getCoopMod()->getHostName(), filename);
+	}
 
 	// the map data must be reset for the next use (fix)
 	mapData = "";

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -183,6 +183,84 @@ void clearNetworkSessionQueues();
 
 class Game;
 class Ufo;
+class SavedGame;
+
+// ===== Coop session lifecycle state =====
+
+enum class CoopRole { None, Host, Client };
+
+/**
+ * Single owner of session-lifecycle state, replacing the scattered statics
+ * that produced three flavors of the same missed/mis-ordered-reset bug.
+ * Rules:
+ *  - exactly TWO reset paths (resetSession / onClientDrop) - never clear
+ *    fields ad hoc;
+ *  - mutate through the named transitions where one fits, so every lifecycle
+ *    change is searchable and logged (PRD-12 S4: the encoding is the mirrored
+ *    booleans below; every multi-field or cross-file write funnels through a
+ *    named, logged transition - there is no separate phase enum to drift from);
+ *  - mutate on the main thread. The network threads keep signaling through
+ *    onConnect and the pump/teardown translate. (The thread-side role writes
+ *    and the transport-glue mirrors that predate this struct are kept raw and
+ *    commented - see the residual list in the PRD-12 commit.)
+ */
+struct CoopSession
+{
+	CoopRole role = CoopRole::None;
+
+	// what the lobby is for: 0 = legacy/new-battle (ready dance),
+	// 1 = new co-op campaign (START CAMPAIGN), 2 = resuming a co-op save
+	int lobbyMode = 0;
+	// a client has passed every join gate (roster, password) and is attached;
+	// onConnect==1 only means "listening", so this is the real presence signal
+	bool clientInLobby = false;
+	// players/teams locked (campaign started, resume began, or legacy ready
+	// dance completed)
+	bool sessionLocked = false;
+	// the lobby UI has been dismissed - the session is considered live.
+	// Defaults TRUE (historical isLobbyMenuClosed semantics: "no lobby open");
+	// LobbyMenu's constructor clears it.
+	bool lobbyClosed = true;
+	// resume handshake: a client reported its world loaded (CoopState 62/64)
+	bool resumeAck = false;
+	// battle-save resume is two-phase: geoscape world first, then the battle
+	// stream; set while phase two is still owed
+	bool resumeBattlePending = false;
+	// PRD-11 C8: names of clients that were actually SERVED a resume world blob
+	// this resume cycle. Only an eligible acker gets the battle stream; a
+	// registered-but-no-blob client (routed through fresh base building) must
+	// not. Cleared together with resumeBattlePending.
+	std::set<std::string> resumeBattleEligible;
+	// set on clients when the host begins/resumes the campaign; releases the
+	// "waiting for players" hold (CoopState 65)
+	bool campaignBegun = false;
+	// host .sav awaiting a re-save once the fresh client blob arrives
+	// (stale-embed race fix)
+	std::string pendingHostSaveName;
+
+	// --- named transitions (each logs; the log line is the lifecycle trace) ---
+	void beginHosting();     // main menu/new game -> hosting a lobby
+	void beginJoining();     // client connecting to a host
+	void clientAttached();   // a client passed every join gate
+	void campaignStarted();  // players/teams locked (START / campaign_start / ready-dance done)
+	void sessionLive();      // waiting dialogs released - play begins/resumes
+	void freeze();           // a registered player dropped mid-session (D5)
+	void setRole(CoopRole r);// main-thread role change (setServerOwner)
+
+	// --- multi-field / cross-file lifecycle writes funnelled here (PRD-12) ---
+	void adoptResumeSave();          // a co-op save is loaded for resume (lobbyMode=2, unlock, clear ack)
+	void armResumeHandshake(bool hasBattle); // resume/rejoin: clear ack, arm battle phase-two if a battle is loaded
+	void markLobbyOpen();            // the lobby UI opened (lobbyClosed=false)
+	void markLobbyClosed();          // the lobby UI dismissed (lobbyClosed=true)
+	void armDeferredSave(const std::string& name); // host save deferred until the fresh client blob arrives
+	void clearDeferredSave();        // deferred host save consumed/cleared
+	void signalCampaignBegun();      // host began/resumed: release the client hold (campaignBegun=true)
+	void consumeCampaignBegun();     // client consumed the release / cleared a stale one (campaignBegun=false)
+
+	// --- the ONLY reset paths ---
+	void resetSession();     // full teardown / back to main menu
+	void onClientDrop();     // host side: the campaign/lobby context survives
+};
 
 class connectionTCP
 {
@@ -284,8 +362,12 @@ class connectionTCP
 	static void sendTCPPacketStaticData2(std::string data);
 	void writeHostMapFile2();
 	void writeHostMapFile();
-	void writeHostMapSaveProgressFile();
+	bool writeHostMapSaveProgressFile();
 	void writeHostMapLoadProgressFile();
+	// PRD-06: write the armed deferred host save exactly once (embedding the
+	// current client blob) and disarm. Used by both the completed round-trip
+	// and the wait-dialog CANCEL path. No-op if nothing armed / a battle is live.
+	void writePendingHostSave();
 	bool inventory_battle_window = true; // Do not use inventory if another player joins a saved game
 	static bool getServerOwner();
 	bool ready_coop_battle = false; // notify the other player that the co-op mission is starting
@@ -367,8 +449,6 @@ class connectionTCP
 	static bool _enable_xcom_equipment_aliens_pvp;
 
 	static bool _unbalanced_craft_soldiers_limit;
-
-	static bool _host_save_progress;
 
 	int walk_end_unit_id = -1;
 
@@ -489,7 +569,50 @@ class connectionTCP
 	static std::unordered_map<std::string, std::string> coopFilesHost;
 	// Stores coop files in a hash map instead of separate files in the client folders
 	static std::unordered_map<std::string, std::string> coopFilesClient;
+	// Guards both blob maps: the loopData streamer thread reads them while the
+	// main thread stores/erases entries. Hold only around map access; copy the
+	// blob out before any long work.
+	static std::mutex coopFilesMutex;
 	static bool hasCoopFile(const std::string& key);
+	// Canonical world-blob keys, scoped by the current saveID:
+	// host_<saveID>_<clientName>.data / client_<saveID>_<hostName>.data
+	static std::string hostBlobKey(const std::string& clientName);
+	static std::string clientBlobKey(const std::string& hostName);
+	// Newest stored world blob for a given client, matched by EXACT player-name
+	// field across any saveID (the host re-mints saveID on every save, so the
+	// stored key's id can lag the current one). Returns nullptr if none. Blob
+	// identity comes from the caller's roster, never from reverse-parsing keys.
+	// CALLER MUST HOLD coopFilesMutex; the returned pointer is valid only while
+	// that lock is held.
+	static const std::string* findHostClientBlob(const std::string& clientName);
+	// Single authority: may this machine read/write local .sav files right now?
+	// Truth table: solo play -> yes; coop host -> yes; coop client -> no.
+	// Every local save/load gate and Load/Save button-visibility decision must
+	// route through this so the rule lives in one place (PRD-08 tunes the host
+	// case later by editing only this function).
+	static bool localSavesAllowed();
+	// PRD-08 C7: may this machine LOAD a local save RIGHT NOW? False whenever a
+	// live coop session is attached (host OR client) - loading mid-session forks
+	// the served world silently. True when solo / after the session ends (the
+	// lobby resume/rejoin flows are the sanctioned way to change worlds).
+	static bool localLoadsAllowed();
+	// One authority for the packet that creates/refreshes a client world
+	// (fields: state=campaign_start, difficulty, gamemode, saveID, players[]).
+	// Built identically by host lobby start, resume-no-blob, and the
+	// request_load_progress no-blob fallback.
+	static Json::Value buildCampaignStartPacket(const SavedGame* save);
+	// STATELESS campaign-context check derived from the live save (a co-op
+	// campaign world is loaded). Prefer this over session.lobbyMode for
+	// host-side routing decisions: lobby mode is transport-lifecycle state.
+	bool inCoopCampaignContext() const;
+
+	// The single owner of session-lifecycle state: see CoopSession above the
+	// class. Mutate via its named transitions / the two reset methods.
+	static CoopSession session;
+
+	// Reason string from the last lobby_join_refused, shown by the refusal
+	// dialog (CoopState 63).
+	static std::string joinRefusalReason;
 
 	// save
 	static bool saveError;
@@ -499,15 +622,17 @@ class connectionTCP
 	static bool isPasswordRequired;
 	static std::string password;
 
-	// lobby menu
-	static bool isCoopSessionLocked;
+	// lobby menu (legacy ready-dance fields; campaign lobbies don't use them)
 	static bool isPlayerReady;
 	static bool isPlayersReady;
 	static int LobbyFileStatus;
 	static int lobby_timer;
+	// PRD-11 C13: one-shot signal from the network thread that the host replied
+	// "busy" to a request_load_progress. The client's load-wait dialog (CoopState
+	// 52) consumes it and schedules a retry.
+	static bool loadProgressBusy;
 	static bool forceCloseCoopStateMenu;
 	static bool forceClosePasswordCheckMenu;
-	static bool isLobbyMenuClosed;
 
 	// other
 	static int manuallyAddedServerRemoveID;

--- a/src/CoopMod/connectionUDP/connection_rendezvous_glue.cpp
+++ b/src/CoopMod/connectionUDP/connection_rendezvous_glue.cpp
@@ -34,7 +34,6 @@ namespace OpenXcom
 
 extern int onConnect;
 extern bool coopSession;
-extern bool server_owner;
 extern bool onTcpHost;
 
 namespace
@@ -334,7 +333,7 @@ static void resetLobbyStateAfterRemoteDisconnect()
 {
     // Remote player is gone. The old TCP disconnect branch will keep the host
     // alive, but the previous ready/locked state is no longer valid.
-    connectionTCP::isCoopSessionLocked = false;
+    connectionTCP::session.sessionLocked = false;
     connectionTCP::isPlayerReady = false;
     connectionTCP::isPlayersReady = false;
     connectionTCP::LobbyFileStatus = -1;
@@ -363,7 +362,7 @@ static void reopenHostRoomAfterRemoteDisconnectAsync()
 
         resetLobbyStateAfterRemoteDisconnect();
         coopSession = false;
-        server_owner = true;
+        connectionTCP::session.role = CoopRole::Host;
         onTcpHost = true;
         onConnect = 2; // host is alive and waiting for a replacement player
 
@@ -450,11 +449,11 @@ static void setHostWaitingState()
     g_rendezvousFlowActive.store(true);
     g_cancelRendezvous.store(false);
     coopSession = false;
-    server_owner = true;
+    connectionTCP::session.role = CoopRole::Host;
     onTcpHost = true;
     onConnect = 1;
 
-    connectionTCP::isCoopSessionLocked = false;
+    connectionTCP::session.sessionLocked = false;
     connectionTCP::isPlayerReady = false;
     connectionTCP::isPlayersReady = false;
     connectionTCP::LobbyFileStatus = -1;
@@ -540,7 +539,7 @@ static void rememberHostRoomForClose(const std::string& rendezvousHost,
                 }
             }
 
-            if (connectionTCP::isCoopSessionLocked)
+            if (connectionTCP::session.sessionLocked)
             {
                 closeListedRoomNow();
                 std::lock_guard<std::mutex> lock(g_roomCloseMutex);
@@ -580,8 +579,8 @@ void disconnectRendezvousUdp()
 
     // connectionTCP::disconnectTCP() decides the branch from the current
     // onConnect value. Do not overwrite full-close state here.
-    const bool hostFullDisconnect = server_owner && onConnect == -1;
-    const bool remotePeerLeftHostAlive = server_owner && onConnect == -2;
+    const bool hostFullDisconnect = connectionTCP::getServerOwner() && onConnect == -1;
+    const bool remotePeerLeftHostAlive = connectionTCP::getServerOwner() && onConnect == -2;
 
     cancelRendezvousOperations();
     stopUdpPeer();
@@ -589,7 +588,7 @@ void disconnectRendezvousUdp()
     if (hostFullDisconnect)
     {
         g_rendezvousFlowActive.store(false);
-        server_owner = false;
+        connectionTCP::session.role = CoopRole::None;
         onTcpHost = false;
         coopSession = false;
         return;
@@ -610,7 +609,7 @@ void disconnectRendezvousUdp()
     }
 
     // Client disconnect or any non-host rendezvous disconnect.
-    if (!server_owner)
+    if (!connectionTCP::getServerOwner())
         g_rendezvousFlowActive.store(false);
 }
 
@@ -624,7 +623,7 @@ void handleUdpRemotePeerLost()
     // covers both a graceful F_CLOSE and a forced client shutdown detected by
     // UDP timeout. Do not call disconnectRendezvousUdp() here because this may
     // run from the UDP monitor thread; stopUdpPeer() would try to join itself.
-    if (server_owner && onConnect != -1)
+    if (connectionTCP::getServerOwner() && onConnect != -1)
     {
         // Host stays alive and relists the room for another player.
         g_rendezvousFlowActive.store(true);
@@ -635,7 +634,7 @@ void handleUdpRemotePeerLost()
         return;
     }
 
-    if (!server_owner && onConnect != -1)
+    if (!connectionTCP::getServerOwner() && onConnect != -1)
     {
         // Client lost the host/peer. This is a remote loss, not a user-requested
         // full host shutdown, and the client's rendezvous flow is over.
@@ -1651,8 +1650,8 @@ bool closeListedRoomViaRendezvous()
 {
     // Manual safety hook. Normally hostListedViaRendezvous(...) starts a
     // background monitor which calls this automatically after
-    // connectionTCP::isCoopSessionLocked becomes true.
-    if (!connectionTCP::isCoopSessionLocked)
+    // connectionTCP::session.sessionLocked becomes true.
+    if (!connectionTCP::session.sessionLocked)
         return false;
 
     return closeListedRoomNow();

--- a/src/CoopMod/connectionUDP/connection_udp_glue.cpp
+++ b/src/CoopMod/connectionUDP/connection_udp_glue.cpp
@@ -36,10 +36,9 @@ namespace OpenXcom
 // These are currently globals in the provided connectionTCP.cpp. They are kept
 // here to avoid changing all old TCP code at once. g_txQ and g_rxQ are declared
 // in connectionTCP.h, so do not redeclare them here with another type. New
-// connectionTCP static state, such as connectionTCP::isCoopSessionLocked, is
+// connectionTCP static state, such as connectionTCP::session.sessionLocked, is
 // used directly below.
 extern int onConnect;
-extern bool server_owner;
 extern bool onTcpHost;
 extern bool clearPackets;
 extern bool coopSession;
@@ -314,11 +313,11 @@ bool startUdpPeer(const std::string& remoteHost,
 	// lobby variables.
 	s_udpEnabled = true;
 	coopSession = true;
-	server_owner = isHost;
+	connectionTCP::session.role = isHost ? CoopRole::Host : CoopRole::Client;
 	onTcpHost = isHost;
 	onConnect = 1;
 
-	connectionTCP::isCoopSessionLocked = false;
+	connectionTCP::session.sessionLocked = false;
 	connectionTCP::isPlayerReady = false;
 	connectionTCP::isPlayersReady = false;
 	connectionTCP::LobbyFileStatus = -1;
@@ -403,7 +402,7 @@ void lockUdpSessionWhenBothReady()
 		s_connectionUDP->lockSessionToCurrentPeer();
 
 	// Match existing TCP lobby state, so old UI/game logic sees the same state.
-	connectionTCP::isCoopSessionLocked = true;
+	connectionTCP::session.sessionLocked = true;
 	connectionTCP::isPlayersReady = true;
 }
 

--- a/src/CoopMod/connectionUDP/rendezvous_client.h
+++ b/src/CoopMod/connectionUDP/rendezvous_client.h
@@ -151,7 +151,7 @@ public:
     static bool joinRoomAndWait(const JoinRoomConfig& cfg, Result& out, std::string* error = nullptr);
 
     // Host-only: closes/removes the listed room after the game lobby has locked.
-    // This should be called only after connectionTCP::isCoopSessionLocked becomes true.
+    // This should be called only after connectionTCP::session.sessionLocked becomes true.
     static bool closeRoom(const RoomControlConfig& cfg, std::string* error = nullptr);
 
     // Compatibility wrapper for old manual JOIN flow.

--- a/src/CoopMod/connectionUDP/rendezvous_server.cpp
+++ b/src/CoopMod/connectionUDP/rendezvous_server.cpp
@@ -873,7 +873,7 @@ namespace
         if (closeRoom)
         {
             // The host sends CLOSE_ROOM only after the game lobby reports
-            // connectionTCP::isCoopSessionLocked == true, meaning all players
+            // connectionTCP::session.sessionLocked == true, meaning all players
             // clicked Ready and the actual game session is locked.
             room->closed = true;
             room->locked = true;

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -578,7 +578,6 @@ void createAdvancedOptionsOTHER()
 	_info.push_back(OptionInfo(OPTION_OTHER, "EnableReactionFirePvp", &EnableReactionFirePvp, true, "Enable Reaction Fire in PvP", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo(OPTION_OTHER, "EnableOtherPlayerFootsteps", &EnableOtherPlayerFootsteps, true,"Enable Other Player Footstep Sounds", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo(OPTION_OTHER, "EnableXcomEquipmentAliensPVP", &EnableXcomEquipmentAliensPVP, true, "Enable XCOM Equipment for Aliens in PVP", "STR_BATTLESCAPE"));
-	_info.push_back(OptionInfo(OPTION_OTHER, "HostSaveProgress", &HostSaveProgress, true, "Only Host Can Save Each Player's Progress", "STR_AI"));
 	_info.push_back(OptionInfo(OPTION_OTHER, "debugMode", &debugMode, true, "Enable Debug Mode (requires restart)", "STR_AI"));
 	_info.push_back(OptionInfo(OPTION_OTHER, "logInfoToFile", &logInfoToFile, false, "Write INFO messages to log file", "STR_AI"));
 	_info.push_back(OptionInfo(OPTION_OTHER, "logPacketMessages", &logPacketMessages, false, "Write packet messages to log files (heavy logging)", "STR_AI"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -97,7 +97,6 @@ OPT bool EnableReactionFirePvp;
 OPT bool EnableOtherPlayerFootsteps;
 OPT bool EnableHostOnlyTimeSpeed;
 OPT bool EnableXcomEquipmentAliensPVP;
-OPT bool HostSaveProgress;
 OPT bool debugMode;
 OPT bool logInfoToFile;
 OPT bool logPacketMessages;

--- a/src/Geoscape/BaseNameState.cpp
+++ b/src/Geoscape/BaseNameState.cpp
@@ -28,6 +28,8 @@
 #include "../Basescape/PlaceLiftState.h"
 #include "../Engine/Options.h"
 #include "../Engine/RNG.h"
+#include "../CoopMod/CoopState.h"
+#include "../CoopMod/connectionTCP.h"
 
 namespace OpenXcom
 {
@@ -165,7 +167,7 @@ void BaseNameState::btnOkClick(Action *)
 		}
 
 		// coop
-		if (connectionTCP::_host_save_progress == true && _game->getCoopMod()->getCoopStatic() == true && _first && _game->getCoopMod()->getServerOwner() == false)
+		if (_game->getCoopMod()->getCoopStatic() == true && _first && _game->getCoopMod()->getServerOwner() == false)
 		{
 
 			Json::Value root;
@@ -173,6 +175,29 @@ void BaseNameState::btnOkClick(Action *)
 
 			_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
 
+			// campaign flow: ship the freshly built world to the host so its
+			// "all players placed bases" gate can open (F2); on a resume or
+			// rejoin this also reports us loaded (F3/F4; stray acks with no
+			// waiting dialog are ignored). Then hold with frozen time until
+			// the host resumes the campaign (D5).
+			if (connectionTCP::session.lobbyMode != 0)
+			{
+				_game->getCoopMod()->pushProgressToHostSilently();
+
+				Json::Value ack;
+				ack["state"] = "resume_ack";
+				_game->getCoopMod()->sendTCPPacketData(ack.toStyledString());
+
+				_game->pushState(new CoopState(COOP_DLG_CLIENT_HOLD));
+			}
+
+		}
+
+		// new-campaign flow: the host holds here until every player's world
+		// blob has arrived (F2)
+		if (_game->getCoopMod()->getCoopStatic() == true && _first && _game->getCoopMod()->getServerOwner() == true && connectionTCP::session.lobbyMode == 1)
+		{
+			_game->pushState(new CoopState(COOP_DLG_WAIT_BASES));
 		}
 
 	}

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -767,7 +767,12 @@ void GeoscapeState::handle(Action *action)
 			}
 			else if (action->getDetails()->key.keysym.sym == Options::keyQuickLoad)
 			{
-				popup(new LoadGameState(OPT_GEOSCAPE, SAVE_QUICK, _palette));
+				// coop: no local load during a live session (client has no local
+				// saves; host mid-session load would fork the world - C7/PRD-08).
+				if (_game->getCoopMod()->localLoadsAllowed())
+				{
+					popup(new LoadGameState(OPT_GEOSCAPE, SAVE_QUICK, _palette));
+				}
 			}
 		}
 	}
@@ -976,50 +981,45 @@ void GeoscapeState::init()
 			return;
 		}
 
-		SavedGame *newsave = new SavedGame();
-
-		
-		std::string filename = "coop_geoscape_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".sav";
-		std::string filepath = Options::getMasterUserFolder() + filename;
-
-		std::string coopKey = "client_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".data";
-
-		if (connectionTCP::_host_save_progress == true && connectionTCP::getServerOwner() == false)
+		std::string coopKey;
+		if (connectionTCP::getServerOwner() == false)
 		{
-			// If the player�s save file isn�t found, try to find the basehost file in memory.
+			coopKey = connectionTCP::clientBlobKey(_game->getCoopMod()->getHostName());
+
+			// If the player's own-world blob isn't found, try the basehost blob.
 			if (!_game->getCoopMod()->hasCoopFile(coopKey))
 			{
 				coopKey = "basehost";
 			}
-
-			newsave->loadCoopSaveFromMemory(coopKey, _game->getMod(), _game->getLanguage(), coopKey);
 		}
 		else
 		{
-
-			filename = "coop_geoscape_" + std::to_string(connectionTCP::saveID) + "_" + _game->getCoopMod()->getHostName() + ".sav";
-			filepath = Options::getMasterUserFolder() + filename;
-
-			bool found = false;
-
-			// Check if the coop_geoscape.sav save exists!
-			if (OpenXcom::CrossPlatform::fileExists(filepath))
+			// Server owner returning from a mission it didn't battle-host:
+			// reload the geoscape snapshot stashed at mission sync, falling
+			// back to the last basehost snapshot.
+			coopKey = "coop_geoscape_return";
+			if (!_game->getCoopMod()->hasCoopFile(coopKey))
 			{
-				found = true;
+				// PRD-09: this snapshot should exist for every mission the server
+				// owner enters (mission start stashes it; F3 resume re-stashes it).
+				// Falling back to 'basehost' rolls the campaign back to session
+				// start - log it so any future gap is visible in harness logs.
+				Log(LOG_WARNING) << "[coop] mission-end restore: no 'coop_geoscape_return' snapshot - falling back to 'basehost' (rolls the campaign back to session start)";
+				coopKey = "basehost";
 			}
-
-			// Check if the _autogeo_.asav save exists!
-			if (found == false)
-			{
-
-				filename = "_autogeo_.asav";
-				filepath = Options::getMasterUserFolder() + filename;
-			}
-
-			newsave->load(filename, _game->getMod(), _game->getLanguage());
-
 		}
-		
+
+		if (!_game->getCoopMod()->hasCoopFile(coopKey))
+		{
+			// No world snapshot to merge into - keep the live (post-battle)
+			// world rather than loading an empty one and wiping the campaign.
+			Log(LOG_ERROR) << "[coop] mission-end reload: no world blob ('" << coopKey << "') - keeping live world";
+			return;
+		}
+
+		SavedGame *newsave = new SavedGame();
+		newsave->loadCoopSaveFromMemory(coopKey, _game->getMod(), _game->getLanguage(), coopKey);
+
 
 		// OLD SAVE SOLDIERS FROM BATTLE (CLIENT)
 		Base *base_selected = new Base(*_game->getSavedGame()->getSelectedBase());
@@ -1129,28 +1129,19 @@ void GeoscapeState::init()
 
 		}
 	
-		// save
-		if (connectionTCP::_host_save_progress == true && connectionTCP::getServerOwner() == false)
-		{
-			newsave->saveCoopToMemory(coopKey, _game->getMod(), coopKey);
-		}
-		else
-		{
-			newsave->save(filename, _game->getMod());
-		}
+		// save back to memory and reload the merged world from it
+		newsave->saveCoopToMemory(coopKey, _game->getMod(), coopKey);
+
+		// newsave owns everything it loaded from the blob; base_selected is a
+		// SHALLOW copy of the live base (Base has no copy ctor and ~Base
+		// deletes members), so deleting it would free the live world.
+		delete newsave;
 
 		_game->getCoopMod()->inventory_battle_window = true;
 
 		_game->popState();
 
-		if (connectionTCP::_host_save_progress == true && connectionTCP::getServerOwner() == false)
-		{
-			_game->pushState(new LoadGameState(OPT_GEOSCAPE, coopKey, _palette, coopKey));
-		}
-		else
-		{
-			_game->pushState(new LoadGameState(OPT_GEOSCAPE, filename, _palette));
-		}
+		_game->pushState(new LoadGameState(OPT_GEOSCAPE, coopKey, _palette, coopKey));
 
 		// COOP FIX
 		if (_game->getCoopMod()->getServerOwner() == true)

--- a/src/Geoscape/MonthlyReportState.cpp
+++ b/src/Geoscape/MonthlyReportState.cpp
@@ -367,12 +367,12 @@ void MonthlyReportState::btnOkClick(Action *)
 		{
 			_game->pushState(new PsiTrainingState);
 		}
-		// Autosave
-		if (_game->getSavedGame()->isIronman() && (_game->getCoopMod()->getCoopStatic() == false || connectionTCP::_host_save_progress == false || (connectionTCP::_host_save_progress == true && _game->getCoopMod()->getServerOwner() == true)))
+		// Autosave (the coop client-side gate in SaveGameState swallows these)
+		if (_game->getSavedGame()->isIronman())
 		{
 			_game->pushState(new SaveGameState(OPT_GEOSCAPE, SAVE_IRONMAN, _palette));
 		}
-		else if (Options::autosave && (_game->getCoopMod()->getCoopStatic() == false || connectionTCP::_host_save_progress == false || (connectionTCP::_host_save_progress == true && _game->getCoopMod()->getServerOwner() == true)))
+		else if (Options::autosave)
 		{
 			_game->pushState(new SaveGameState(OPT_GEOSCAPE, SAVE_AUTO_GEOSCAPE, _palette));
 		}
@@ -396,7 +396,7 @@ void MonthlyReportState::btnOkClick(Action *)
 			}
 
 			_game->pushState(new CutsceneState(cutsceneId));
-			if (_game->getSavedGame()->isIronman() && (_game->getCoopMod()->getCoopStatic() == false || connectionTCP::_host_save_progress == false || (connectionTCP::_host_save_progress == true && _game->getCoopMod()->getServerOwner() == true)))
+			if (_game->getSavedGame()->isIronman())
 			{
 				_game->pushState(new SaveGameState(OPT_GEOSCAPE, SAVE_IRONMAN, _palette));
 			}

--- a/src/Menu/LoadGameState.cpp
+++ b/src/Menu/LoadGameState.cpp
@@ -35,6 +35,8 @@
 #include "../Engine/Unicode.h"
 #include "../Mod/RuleInterface.h"
 #include "StatisticsState.h"
+#include "../CoopMod/HostMenu.h"
+#include "../CoopMod/CoopState.h"
 
 namespace OpenXcom
 {
@@ -62,7 +64,7 @@ LoadGameState::LoadGameState(OptionsOrigin origin, const std::string& filename, 
  * @param type Type of auto-load being used.
  * @param palette Parent state palette.
  */
-LoadGameState::LoadGameState(OptionsOrigin origin, SaveType type, SDL_Color *palette) : _firstRun(0), _origin(origin)
+LoadGameState::LoadGameState(OptionsOrigin origin, SaveType type, SDL_Color *palette) : _firstRun(0), _origin(origin), _loadCoopProgress(false)
 {
 
 	// coop
@@ -142,6 +144,20 @@ void LoadGameState::buildUi(SDL_Color *palette)
 void LoadGameState::init()
 {
 	State::init();
+
+	// Chokepoint gate: a machine that may not touch local saves (coop client)
+	// can only reach a plain local load through the pause menu / list / confirm
+	// states or a directly-pushed LoadGameState. The coop-orchestrated flows -
+	// loading a host-provided blob (_coopKey set) or a resume/rejoin
+	// (_loadCoopProgress) - are NOT local loads and must still run. Refuse only
+	// the plain local load.
+	if (!_game->getCoopMod()->localLoadsAllowed() && _coopKey.empty() && !_loadCoopProgress)
+	{
+		Log(LOG_INFO) << "[coop] local load refused: no local loads during a live coop session (PRD-08)";
+		_game->popState();
+		return;
+	}
+
 	if (_filename == SavedGame::QUICKSAVE && !CrossPlatform::fileExists(Options::getMasterUserFolder() + _filename))
 	{
 		_game->popState();
@@ -216,6 +232,19 @@ void LoadGameState::think()
 				if (_loadCoopProgress == true)
 				{
 					_game->getSavedGame()->setBattleGame(0);
+
+					// resume/rejoin: report the loaded world to the host and
+					// hold with frozen time until it resumes (F3/F4/D5)
+					if (connectionTCP::session.lobbyMode != 0 && _game->getCoopMod()->getServerOwner() == false)
+					{
+						Json::Value root;
+						root["state"] = "resume_ack";
+						_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+
+						// (in a battle resume the follow-up battle stream
+						// replaces the whole state stack, dialog included)
+						_game->pushState(new CoopState(COOP_DLG_CLIENT_RESUME_HOLD));
+					}
 				}
 
 				if (_game->getSavedGame()->getSavedBattle() != 0)
@@ -372,6 +401,32 @@ void LoadGameState::think()
 					_game->getSavedGame()->getSavedBattle()->setBattleState(bs);
 					// Try to reactivate the touch buttons
 					bs->toggleTouchButtons(false, true);
+
+					// battle-save resume / mid-battle rejoin, phase two
+					// complete: report the loaded battle to the host (F3/F4)
+					if (connectionTCP::session.lobbyMode != 0 && _game->getCoopMod()->getServerOwner() == false && _coopKey == "battleclient")
+					{
+						Json::Value root;
+						root["state"] = "resume_ack";
+						_game->getCoopMod()->sendTCPPacketData(root.toStyledString());
+					}
+				}
+
+				// flow-redesign F3: a co-op campaign save loaded from the
+				// menu opens a lobby-gated session - host window on top of
+				// the paused world; RESUME serves every client its world.
+				if (_coopKey.empty()
+					&& _game->getSavedGame()->isCoopSave()
+					&& _game->getCoopMod()->getCoopStatic() == false)
+				{
+					connectionTCP::session.adoptResumeSave();
+					// the host identity is locked to the save (D4): adopt it,
+					// so the UI flow can never host under a different name
+					if (!_game->getSavedGame()->getCoopPlayers().empty())
+					{
+						_game->getCoopMod()->setHostName(_game->getSavedGame()->getCoopPlayers()[0]);
+					}
+					_game->pushState(new HostMenu());
 				}
 			}
 

--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -40,6 +40,77 @@
 namespace OpenXcom
 {
 
+/**
+ * Dropdown shown under the main menu's New Game button: the campaign is
+ * permanently Solo or Co-op from creation (flow-redesign D1). File-local so
+ * no new translation unit is needed.
+ */
+class NewGameModeState : public State
+{
+private:
+	Window *_window;
+	TextButton *_btnSolo, *_btnCoop;
+public:
+	NewGameModeState()
+	{
+		_screen = false;
+
+		// anchored directly under the New Game button (64,90 / 92x20)
+		_window = new Window(this, 100, 52, 60, 88, POPUP_VERTICAL);
+		_btnSolo = new TextButton(92, 20, 64, 92);
+		_btnCoop = new TextButton(92, 20, 64, 114);
+
+		setInterface("mainMenu");
+
+		add(_window, "window", "mainMenu");
+		add(_btnSolo, "button", "mainMenu");
+		add(_btnCoop, "button", "mainMenu");
+
+		centerAllSurfaces();
+
+		setWindowBackground(_window, "mainMenu");
+
+		_btnSolo->setText("SOLO");
+		_btnSolo->onMouseClick((ActionHandler)&NewGameModeState::btnSoloClick);
+		_btnCoop->setText("CO-OP");
+		_btnCoop->onMouseClick((ActionHandler)&NewGameModeState::btnCoopClick);
+		_btnSolo->onKeyboardPress((ActionHandler)&NewGameModeState::btnCancelClick, Options::keyCancel);
+	}
+
+	void btnSoloClick(Action *)
+	{
+		_game->popState();
+		_game->pushState(new NewGameState(false));
+	}
+
+	void btnCoopClick(Action *)
+	{
+		_game->popState();
+		_game->pushState(new NewGameState(true));
+	}
+
+	void btnCancelClick(Action *)
+	{
+		_game->popState();
+	}
+
+	// clicking outside the dropdown dismisses it
+	void handle(Action *action) override
+	{
+		State::handle(action);
+		if (action->getDetails()->type == SDL_MOUSEBUTTONDOWN)
+		{
+			int mx = action->getAbsoluteXMouse();
+			int my = action->getAbsoluteYMouse();
+			if (mx < _window->getX() || mx >= _window->getX() + _window->getWidth()
+				|| my < _window->getY() || my >= _window->getY() + _window->getHeight())
+			{
+				_game->popState();
+			}
+		}
+	}
+};
+
 GoToMainMenuState::GoToMainMenuState(bool updateCheck) : _updateCheck(updateCheck)
 {
 	// empty
@@ -270,6 +341,7 @@ void MainMenuState::init()
 	_game->getCoopMod()->disconnectTCP(true);
 
 	connectionTCP::_coopGamemode = 0;
+	connectionTCP::session.resetSession();
 	_game->getCoopMod()->coopMissionEnd = false;
 	_game->getCoopMod()->coopInventory = false;
 
@@ -291,7 +363,7 @@ MainMenuState::~MainMenuState()
  */
 void MainMenuState::btnNewGameClick(Action *)
 {
-	_game->pushState(new NewGameState);
+	_game->pushState(new NewGameModeState);
 }
 
 /**

--- a/src/Menu/NewGameState.cpp
+++ b/src/Menu/NewGameState.cpp
@@ -30,6 +30,7 @@
 #include "../Engine/Options.h"
 #include "../Savegame/SavedGame.h"
 #include "../Savegame/Base.h"
+#include "../CoopMod/HostMenu.h"
 
 namespace OpenXcom
 {
@@ -38,7 +39,7 @@ namespace OpenXcom
  * Initializes all the elements in the Difficulty window.
  * @param game Pointer to the core game.
  */
-NewGameState::NewGameState()
+NewGameState::NewGameState(bool coopCampaign) : _coopCampaign(coopCampaign)
 {
 	// Create objects
 	_window = new Window(this, 192, 180, 64, 10, POPUP_VERTICAL);
@@ -128,7 +129,7 @@ NewGameState::NewGameState()
 	_txtIronman->setText(tr("STR_IRONMAN_DESC"));
 
 	// coop
-	if (connectionTCP::_host_save_progress == true && connectionTCP::getCoopStatic() == true)
+	if (connectionTCP::getCoopStatic() == true)
 	{
 		_btnCancel->setVisible(false);
 	}
@@ -177,38 +178,70 @@ void NewGameState::btnOkClick(Action *)
 	SavedGame *save = _game->getMod()->newSave(diff);
 	save->setDifficulty(diff);
 	save->setIronman(_btnIronman->getPressed());
+	if (_coopCampaign)
+	{
+		// permanent solo/co-op distinction (D1)
+		save->setCoopSave(true);
+	}
 	_game->setSavedGame(save);
 
 	GeoscapeState *gs = new GeoscapeState;
 	_game->setState(gs);
 	gs->init();
 
-	auto* base = _game->getSavedGame()->getBases()->back();
+	if (_coopCampaign)
+	{
+		// Co-op: base placement happens after START CAMPAIGN. The geoscape
+		// sits paused underneath the host window and lobby.
+		connectionTCP::session.lobbyMode = 1;
+		_game->pushState(new HostMenu());
+		return;
+	}
+
+	beginInitialBasePlacement(_game, gs, _game->getSavedGame()->getBases()->back());
+
+}
+
+// Shared kickoff for solo new game, host lobby start, and client
+// campaign_start. Kept beside the vanilla original so the next OXCE rebase
+// surfaces conflicts in one file.
+void beginInitialBasePlacement(Game* game, GeoscapeState* gs, Base* base)
+{
+	// latitude nudge so the base marker sits above the name-entry window;
+	// matches the vanilla value (~35 degrees down).
+	const double kInitialBaseLatOffset = 0.61;
+
+	// Null-tolerant on gs: the lobby-start caller scans the state stack for the
+	// geoscape and may not find one; do nothing rather than crash.
+	if (!gs)
+	{
+		return;
+	}
+
 	if (base->getMarker() != -1)
 	{
-		// location known already
-		base->calculateServices(save);
+		// location known already (custom initial base mods)
+		base->calculateServices(game->getSavedGame());
 
-		// center and rotate 35 degrees down (to see the base location while typoing its name)
-		gs->getGlobe()->center(base->getLongitude(), base->getLatitude() + 0.61);
+		// center and rotate down so the base location is visible while naming
+		gs->getGlobe()->center(base->getLongitude(), base->getLatitude() + kInitialBaseLatOffset);
 
 		if (base->getName().empty())
 		{
 			// fixed location, custom name
-			_game->pushState(new BaseNameState(base, gs->getGlobe(), true, true));
+			game->pushState(new BaseNameState(base, gs->getGlobe(), true, true));
 		}
 		else if (Options::customInitialBase)
 		{
 			// fixed location, fixed name
-			_game->pushState(new PlaceLiftState(base, gs->getGlobe(), true));
+			game->pushState(new PlaceLiftState(base, gs->getGlobe(), true));
 		}
 	}
 	else
 	{
 		// custom location, custom name
-		_game->pushState(new BuildNewBaseState(base, gs->getGlobe(), true));
+		game->pushState(new BuildNewBaseState(base, gs->getGlobe(), true));
 	}
-
 }
 
 /**

--- a/src/Menu/NewGameState.h
+++ b/src/Menu/NewGameState.h
@@ -26,6 +26,14 @@ class TextButton;
 class ToggleTextButton;
 class Window;
 class Text;
+class Game;
+class GeoscapeState;
+class Base;
+
+// Shared by solo new game, host lobby start, and client campaign_start:
+// centers the globe on the base marker and routes into base naming/placement.
+// Null-tolerant on gs (does nothing if gs is null, mirroring the lobby guard).
+void beginInitialBasePlacement(Game* game, GeoscapeState* gs, Base* base);
 
 /**
  * New Game window that displays a list
@@ -41,9 +49,12 @@ private:
 	TextButton *_btnOk, *_btnCancel;
 	Window *_window;
 	Text *_txtTitle, *_txtIronman;
+	// true = creating a co-op campaign: world is created, base placement is
+	// deferred, and the flow continues into the host window + lobby
+	bool _coopCampaign;
 public:
 	/// Creates the New Game state.
-	NewGameState();
+	NewGameState(bool coopCampaign = false);
 	/// Cleans up the New Game state.
 	~NewGameState();
 	/// Handler for clicking the Ok button.

--- a/src/Menu/PauseState.cpp
+++ b/src/Menu/PauseState.cpp
@@ -144,9 +144,10 @@ PauseState::PauseState(OptionsOrigin origin) : _origin(origin)
 		_btnAbandon->setText(tr("STR_SAVE_AND_ABANDON_GAME"));
 	}
 
-	// coop
-   // geoscape
-	if (_game->getCoopMod()->getCoopStatic() == true || _game->getCoopMod()->getServerOwner() == true)
+	// coop: PRD-08 - hide Load whenever local loads are forbidden right now (any
+	// live coop session, host included). Outside a live session the button follows
+	// the normal/ironman rules above.
+	if (!_game->getCoopMod()->localLoadsAllowed())
 	{
 		_btnLoad->setVisible(false);
 	}
@@ -156,15 +157,6 @@ PauseState::PauseState(OptionsOrigin origin) : _origin(origin)
 
 		_btnLoad->setVisible(false);
 		_btnSave->setVisible(false);
-
-	}
-
-	// Client-side error
-	if (_game->getCoopMod()->getCoopStatic() == false && _game->getCoopMod()->isCoopSession() == true)
-	{
-
-		// Show the save button only for bugs that have occurred!
-		_btnSave->setVisible(true);
 
 	}
 
@@ -186,24 +178,13 @@ PauseState::PauseState(OptionsOrigin origin) : _origin(origin)
 		}
 	}
 
-	if (connectionTCP::_host_save_progress == false && _game->getCoopMod()->getHost() == false)
-	{
-		_btnSave->setVisible(false);
-	}
-
-	if (connectionTCP::_host_save_progress == false && _game->getCoopMod()->getHost() == true)
-	{
-		_btnSave->setVisible(true);
-	}
-
-	//  coop
-	if (_origin == OPT_GEOSCAPE && connectionTCP::_host_save_progress == false)
-	{
-		_btnSave->setVisible(true);
-	}
-
-	// coop
-	if (_game->getCoopMod()->isCoopSession() == false && _game->getCoopMod()->getServerOwner() == false)
+	// coop: re-show Load/Save only when this machine is truly solo. The old
+	// condition (!isCoopSession && !host) also fired for a coop-static client
+	// during the brief window where isCoopSession reads false, re-exposing local
+	// load/save to a client. Gating on localSavesAllowed() (which is false for a
+	// client) plus !host keeps the host's Load hidden (its policy is PRD-08) and
+	// preserves solo behavior exactly.
+	if (_game->getCoopMod()->localSavesAllowed() && _game->getCoopMod()->getServerOwner() == false)
 	{
 		_btnLoad->setVisible(true);
 		_btnSave->setVisible(true);
@@ -247,8 +228,9 @@ void PauseState::btnLoadClick(Action *)
 void PauseState::btnSaveClick(Action *)
 {
 
-	// Client-side error
-	if (_game->getCoopMod()->getCoopStatic() == false && _game->getCoopMod()->isCoopSession() == true)
+	// A machine that may not touch local saves (coop client) gets an error
+	// popup instead of the save list. Same authority as every other gate.
+	if (!_game->getCoopMod()->localSavesAllowed())
 	{
 		_game->pushState(new CoopState(123));
 	}
@@ -264,7 +246,7 @@ void PauseState::btnCoopClick(Action *)
 {
 
 	// Open the host menu if the host saves the players' campaign progress, the client joins the game through the main menu (New Battle)
-	if (Options::HostSaveProgress == true && _game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == false && _game->getCoopMod()->getCoopStatic() == false)
+	if (_game->getCoopMod()->getCoopCampaign() == true && _game->getCoopMod()->getServerOwner() == false && _game->getCoopMod()->getCoopStatic() == false)
 	{
 
 		_game->pushState(new HostMenu());
@@ -284,9 +266,9 @@ void PauseState::btnCoopClick(Action *)
 void PauseState::init()
 {
 
-	// coop
-	// geoscape
-	if (_game->getCoopMod()->getCoopStatic() == true || _game->getCoopMod()->getServerOwner() == true)
+	// coop: PRD-08 - hide Load whenever local loads are forbidden right now (any
+	// live coop session, host included).
+	if (!_game->getCoopMod()->localLoadsAllowed())
 	{
 		_btnLoad->setVisible(false);
 	}
@@ -297,31 +279,9 @@ void PauseState::init()
 		_btnSave->setVisible(false);
 	}
 
-	// Client-side error
-	if (_game->getCoopMod()->getCoopStatic() == false && _game->getCoopMod()->isCoopSession() == true)
-	{
-		// Show the save button only for bugs that have occurred!
-		_btnSave->setVisible(true);
-	}
-
-	if (connectionTCP::_host_save_progress == false && _game->getCoopMod()->getHost() == false)
-	{
-		_btnSave->setVisible(false);
-	}
-
-	if (connectionTCP::_host_save_progress == false && _game->getCoopMod()->getHost() == true)
-	{
-		_btnSave->setVisible(true);
-	}
-
-	//  coop
-	if (_origin == OPT_GEOSCAPE && connectionTCP::_host_save_progress == false)
-	{
-		_btnSave->setVisible(true);
-	}
-
-	// coop
-	if (_game->getCoopMod()->isCoopSession() == false && _game->getCoopMod()->getServerOwner() == false)
+	// coop: re-show Load/Save only when truly solo (see init() note above);
+	// never re-expose a coop client to local load/save.
+	if (_game->getCoopMod()->localSavesAllowed() && _game->getCoopMod()->getServerOwner() == false)
 	{
 		_btnLoad->setVisible(true);
 		_btnSave->setVisible(true);

--- a/src/Menu/SaveGameState.cpp
+++ b/src/Menu/SaveGameState.cpp
@@ -186,12 +186,31 @@ void SaveGameState::think()
 			break;
 		}
 
+		// Host-save authority: a coop client never writes save data to disk -
+		// the host save (with the embedded client world) is the single
+		// authority. Swallow the save silently; UI states were popped above.
+		if (!_game->getCoopMod()->localSavesAllowed())
+		{
+			if (_type == SAVE_IRONMAN_END)
+			{
+				Screen::updateScale(Options::geoscapeScale, Options::baseXGeoscape, Options::baseYGeoscape, true);
+				_game->getScreen()->resetDisplay(false);
+
+				_game->setState(new MainMenuState);
+				_game->setSavedGame(0);
+			}
+			return;
+		}
+
 		// Save the game
 		try
 		{
-		
-			// HostSaveProgress
-			if ((_game->getCoopMod()->isCoopSession() == true && connectionTCP::_host_save_progress == true && _game->getCoopMod()->getServerOwner() == true && _game->getSavedGame() && !_game->getSavedGame()->getSavedBattle()) && _game->getCoopMod()->coopMissionEnd == false)
+
+			// host-save authority: a host geoscape save pulls fresh client progress
+			// before writing, so the embedded client world is current. Ironman-end
+			// is excluded (it needs the immediate write + MainMenu transition below).
+			bool deferHostSave = false;
+			if ((_game->getCoopMod()->isCoopSession() == true && _game->getCoopMod()->getServerOwner() == true && _game->getSavedGame() && !_game->getSavedGame()->getSavedBattle()) && _game->getCoopMod()->coopMissionEnd == false && _type != SAVE_IRONMAN_END)
 			{
 
 				if (_type != SAVE_AUTO_GEOSCAPE && _type != SAVE_AUTO_BATTLESCAPE)
@@ -199,9 +218,29 @@ void SaveGameState::think()
 					connectionTCP::saveID = _game->getCoopMod()->getDateTimeCoop();
 				}
 
-				CoopState* coopWindow = new CoopState(54);
+				// PRD-06/E1: arm the deferral and SKIP the immediate write. The
+				// single write happens once the client's fresh world blob arrives
+				// (MAP_RESULT_SAVE_PROGRESS handler -> writePendingHostSave), so
+				// the .sav is serialized+written once, not twice, and always
+				// embeds the freshest client world instead of a round-trip-stale one.
+				connectionTCP::session.armDeferredSave(_filename);
+
+				CoopState* coopWindow = new CoopState(COOP_DLG_HOST_SAVE_WAIT);
 				_game->pushState(coopWindow);
 
+				deferHostSave = true;
+			}
+
+			if (deferHostSave)
+			{
+				// deferred: the handler writes it. Clear the impatient-user input
+				// queue and return without an immediate emit.
+				SDL_Event e;
+				while (SDL_PollEvent(&e))
+				{
+					// do nothing
+				}
+				return;
 			}
 
 			std::string backup = _filename + ".bak";

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -19,6 +19,7 @@
 #include "SavedGame.h"
 #include <sstream>
 #include <set>
+#include <map>
 #include <iomanip>
 #include <algorithm>
 #include <functional>
@@ -111,7 +112,7 @@ bool haveReserchVector(const std::vector<const RuleResearch*> &vec,  const std::
  * Initializes a brand new saved game according to the specified difficulty.
  */
 SavedGame::SavedGame() :
-	_difficulty(DIFF_BEGINNER), _end(END_NONE), _ironman(false), _globeLon(0.0), _globeLat(0.0), _globeZoom(0),
+	_difficulty(DIFF_BEGINNER), _end(END_NONE), _ironman(false), _coop(false), _globeLon(0.0), _globeLat(0.0), _globeZoom(0),
 	_battleGame(0), _previewBase(nullptr), _debug(false), _warned(false),
 	_togglePersonalLight(true), _toggleNightVision(false), _toggleBrightness(0),
 	_monthsPassed(-1), _daysPassed(0), _vehiclesLost(0), _selectedBase(0), _autosales(), _disableSoldierEquipment(false), _alienContainmentChecked(false)
@@ -297,19 +298,25 @@ std::vector<SaveInfo> SavedGame::getList(Language *lang, bool autoquick)
 void SavedGame::loadCoopSaveFromMemory(const std::string& filename, Mod* mod, Language* lang, const std::string& key)
 {
 
-	const auto& coopFiles = connectionTCP::getServerOwner()
-								? connectionTCP::coopFilesHost
-								: connectionTCP::coopFilesClient;
-
-	auto it = coopFiles.find(key);
-	if (it == coopFiles.end())
+	std::string blobCopy;
 	{
-		DebugLog("Error reading from hash map with key: " + key);
-		return;
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+
+		const auto& coopFiles = connectionTCP::getServerOwner()
+									? connectionTCP::coopFilesHost
+									: connectionTCP::coopFilesClient;
+
+		auto it = coopFiles.find(key);
+		if (it == coopFiles.end())
+		{
+			DebugLog("Error reading from hash map with key: " + key);
+			return;
+		}
+		blobCopy = it->second;
 	}
 
 	YAML::YamlRootNodeReader documents(
-		YAML::YamlString{it->second},
+		YAML::YamlString{blobCopy},
 		"<memory>",
 		false);
 
@@ -318,6 +325,8 @@ void SavedGame::loadCoopSaveFromMemory(const std::string& filename, Mod* mod, La
 	_time->load(header["time"]);
 	header.readNode("name", _name, filename);
 	header.tryRead("ironman", _ironman);
+	header.tryRead("coop", _coop);
+	header.tryRead("coopPlayers", _coopPlayers);
 
 	// Get full save data
 	const auto& reader = documents[1].useIndex();
@@ -712,6 +721,14 @@ SaveInfo SavedGame::getSaveInfo(const std::string &file, Language *lang)
 	}
 	save.details = details.str();
 
+	// co-op campaigns are marked in the list so players know the save
+	// demands a session
+	save.coop = reader["coop"].readVal(false);
+	if (save.coop)
+	{
+		save.details = "Co-op - " + save.details;
+	}
+
 	return save;
 }
 
@@ -754,9 +771,24 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 	_time->load(header["time"]);
 	header.readNode("name", _name, filename);
 	header.tryRead("ironman", _ironman);
+	header.tryRead("coop", _coop);
+	header.tryRead("coopPlayers", _coopPlayers);
 
 	// Get full save data
 	const auto& reader = documents[1].useIndex();
+
+	// Old-format co-op saves (made before the campaign flow redesign) carry
+	// coop traces without the coop marker and are unsupported.
+	if (!_coop)
+	{
+		long long oldSaveID = 0;
+		reader.tryRead("saveID", oldSaveID);
+		if (oldSaveID != 0 || reader["coopClientSaves"] || reader["coopClientSaveKey"])
+		{
+			throw Exception("This save was made on an earlier version of the X-COM Co-op Mod that is no longer supported. Please downgrade to an older version or use the save editor to upgrade your save.");
+		}
+	}
+
 	reader.tryRead("difficulty", _difficulty);
 	reader.tryRead("end", _end);
 	if (reader["rng"] && (_ironman || !Options::newSeedOnLoad))
@@ -764,22 +796,40 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 	reader.tryRead("monthsPassed", _monthsPassed);
 
 	// coop
+	// Default to 0 first: a solo/legacy save has no saveID key, and tryRead
+	// leaves the global untouched on a miss - which would let a prior coop
+	// session's saveID leak into this loaded game (fixes C1 on the load side).
+	connectionTCP::saveID = 0;
 	reader.tryRead("saveID", connectionTCP::saveID);
 	reader.tryRead("coop_gamemode", connectionTCP::_coopGamemode);
 	reader.tryRead("coop_save_owner_player_id", connectionTCP::coop_save_owner_player_id);
-	// Single-authority: a host save embeds the client-world blob captured at
-	// save time. Restore it as the served copy (RAM + the sidecar file the
-	// reconnect flow streams), so a rolled-back save rolls the client back too.
+	// Single-authority: a host save embeds every client-world blob captured
+	// at save time. Restore them as the served copies (memory only - the
+	// reconnect flow streams from these), so a rolled-back save rolls every
+	// client back too. The load defines the full served set: stale host blobs
+	// from another campaign/session are dropped first, so a solo or different
+	// save never serves (or re-embeds) a foreign client world.
 	{
-		std::string coopClientKey;
-		reader.tryRead("coopClientSaveKey", coopClientKey);
-		if (!coopClientKey.empty() && reader["coopClientSaveBlob"])
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+		for (auto it = connectionTCP::coopFilesHost.begin(); it != connectionTCP::coopFilesHost.end();)
 		{
-			std::vector<char> blob = reader["coopClientSaveBlob"].readValBase64();
-			std::string blobStr(blob.begin(), blob.end());
-			connectionTCP::coopFilesHost[coopClientKey] = blobStr;
-			CrossPlatform::writeFile(Options::getMasterUserFolder() + coopClientKey, blobStr);
-			Log(LOG_INFO) << "[coop-transfer] restored embedded client blob '" << coopClientKey << "' (" << blobStr.size() << " bytes)";
+			if (it->first.compare(0, 5, "host_") == 0)
+				it = connectionTCP::coopFilesHost.erase(it);
+			else
+				++it;
+		}
+		if (reader["coopClientSaves"])
+		{
+			for (const auto& entry : reader["coopClientSaves"].children())
+			{
+				std::string key;
+				entry.tryRead("key", key);
+				if (key.empty() || !entry["blob"])
+					continue;
+				std::vector<char> blob = entry["blob"].readValBase64();
+				connectionTCP::coopFilesHost[key] = std::string(blob.begin(), blob.end());
+				Log(LOG_INFO) << "[coop-transfer] restored embedded client blob '" << key << "' (" << blob.size() << " bytes)";
+			}
 		}
 	}
 	if (connectionTCP::isCoopBaseLoading == false && connectionTCP::getServerOwner() == false)
@@ -1186,6 +1236,14 @@ void SavedGame::saveCoopToMemory(const std::string& filename, Mod* mod, const st
 	if (_ironman)
 		headerWriter.write("ironman", _ironman);
 
+	// coop campaign markers (kept in blob headers too, so client worlds
+	// loaded from memory carry the same campaign identity)
+	if (_coop)
+	{
+		headerWriter.write("coop", _coop);
+		headerWriter.write("coopPlayers", _coopPlayers);
+	}
+
 	// Saves the full game data to the save
 	YAML::YamlRootNodeWriter writer(1000000); // 1MB starting buffer
 	writer.setAsMap();
@@ -1193,7 +1251,11 @@ void SavedGame::saveCoopToMemory(const std::string& filename, Mod* mod, const st
 	writer.write("end", _end);
 
 	// coop
-	writer.write("saveID", connectionTCP::saveID);
+	// Only a coop save carries a saveID; a solo save must not (the load gate
+	// throws on !_coop && saveID != 0). Same condition as the "coop" header
+	// marker above, so the two can never disagree (fixes C1).
+	if (_coop)
+		writer.write("saveID", connectionTCP::saveID);
 	writer.write("coop_gamemode", connectionTCP::_coopGamemode);
 	writer.write("coop_save_owner_player_id", connectionTCP::coop_save_owner_player_id);
 	writer.write("no_bases", connectionTCP::no_bases);
@@ -1373,13 +1435,16 @@ void SavedGame::saveCoopToMemory(const std::string& filename, Mod* mod, const st
 	finalString += bodyString.yaml;
 
 	// Save to memory
-	if (connectionTCP::getServerOwner() == true)
 	{
-		connectionTCP::coopFilesHost[key] = std::move(finalString);
-	}
-	else
-	{
-		connectionTCP::coopFilesClient[key] = std::move(finalString);
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+		if (connectionTCP::getServerOwner() == true)
+		{
+			connectionTCP::coopFilesHost[key] = std::move(finalString);
+		}
+		else
+		{
+			connectionTCP::coopFilesClient[key] = std::move(finalString);
+		}
 	}
 
 }
@@ -1420,6 +1485,14 @@ void SavedGame::save(const std::string &filename, Mod *mod) const
 	if (_ironman)
 		headerWriter.write("ironman", _ironman);
 
+	// coop campaign markers live in the header so the save list and load
+	// routing can read them without parsing the body
+	if (_coop)
+	{
+		headerWriter.write("coop", _coop);
+		headerWriter.write("coopPlayers", _coopPlayers);
+	}
+
 	// Saves the full game data to the save
 	YAML::YamlRootNodeWriter writer(1000000); //1MB starting buffer
 	writer.setAsMap();
@@ -1427,23 +1500,50 @@ void SavedGame::save(const std::string &filename, Mod *mod) const
 	writer.write("end", _end);
 
 	// coop
-	writer.write("saveID", connectionTCP::saveID);
+	// Only a coop save carries a saveID; a solo save must not (the load gate
+	// throws on !_coop && saveID != 0). Same condition as the "coop" header
+	// marker above, so the two can never disagree (fixes C1).
+	if (_coop)
+		writer.write("saveID", connectionTCP::saveID);
 	writer.write("coop_gamemode", connectionTCP::_coopGamemode);
 	writer.write("coop_save_owner_player_id", connectionTCP::coop_save_owner_player_id);
 	writer.write("no_bases", connectionTCP::no_bases);
-	// Single-authority: embed the freshest client-world blob so this save
-	// captures BOTH players' rosters atomically. Skip when this call is itself
-	// writing a client sidecar (.data) to avoid recursive embedding.
-	if (filename.size() < 5 || filename.substr(filename.size() - 5) != ".data")
+	// Single-authority: embed the freshest client-world blob of EVERY client
+	// so this save captures all players' rosters atomically. Skip when this
+	// call is itself writing a client sidecar (.data) to avoid recursion, and
+	// when no coop campaign session ever ran (saveID 0 - never pollute a solo
+	// campaign's save with another campaign's blobs).
+	bool isSidecarWrite = filename.size() >= 5 && filename.compare(filename.size() - 5, 5, ".data") == 0;
+	if (_coop && connectionTCP::saveID != 0 && !isSidecarWrite)
 	{
-		const std::string prefix = "host_" + std::to_string(connectionTCP::saveID) + "_";
-		for (const auto& kv : connectionTCP::coopFilesHost)
+		// Blob identity comes from the locked roster (host at [0], clients after),
+		// NOT from reverse-parsing map keys: each client's world lives under
+		// hostBlobKey(name) at the current saveID (the store keeps one entry per
+		// client and the saveID is stable within a session - see PRD-04). This
+		// removes the fragile filename find/substr + lexicographic-id selection
+		// that could pick the wrong blob (S8). Keyed by exact name, so player
+		// "Bob" can never collide with "Super_Bob".
+		std::lock_guard<std::mutex> lock(connectionTCP::coopFilesMutex);
+		std::vector<std::pair<std::string, const std::string*>> toEmbed; // (key, blob)
+		for (size_t i = 1; i < _coopPlayers.size(); ++i)
 		{
-			if (kv.first.compare(0, prefix.size(), prefix) == 0 && !kv.second.empty())
+			// blob matched by exact roster name (any saveID); the embedded key is
+			// normalized to the CURRENT saveID so the reconnect flow finds it
+			// after this save is loaded.
+			const std::string* blob = connectionTCP::findHostClientBlob(_coopPlayers[i]);
+			if (blob && !blob->empty())
+				toEmbed.emplace_back(connectionTCP::hostBlobKey(_coopPlayers[i]), blob);
+		}
+		if (!toEmbed.empty())
+		{
+			auto seq = writer["coopClientSaves"];
+			seq.setAsSeq();
+			for (const auto& kb : toEmbed)
 			{
-				writer.write("coopClientSaveKey", kv.first);
-				writer.writeBase64("coopClientSaveBlob", const_cast<char*>(kv.second.data()), kv.second.size());
-				break;
+				auto e = seq.write();
+				e.setAsMap();
+				e.write("key", kb.first);
+				e.writeBase64("blob", const_cast<char*>(kb.second->data()), kb.second->size());
 			}
 		}
 	}

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -95,6 +95,7 @@ struct SaveInfo
 	std::string details;
 	std::vector<std::string> mods;
 	bool reserved;
+	bool coop = false;
 };
 
 struct ModInfoCoop
@@ -162,6 +163,11 @@ private:
 	GameDifficulty _difficulty;
 	GameEnding _end;
 	bool _ironman;
+	// coop campaign markers: set at campaign start, immutable afterwards.
+	// _coop permanently distinguishes co-op campaigns from solo; _coopPlayers
+	// is the locked player list (host first).
+	bool _coop;
+	std::vector<std::string> _coopPlayers;
 	GameTime *_time;
 	std::vector<std::string> _userNotes;
 	std::vector<std::string> _geoscapeDebugLog;
@@ -260,6 +266,19 @@ private:
 	bool isIronman() const;
 	/// Sets if the game is in ironman mode.
 	void setIronman(bool ironman);
+	/// Is this a co-op campaign save (permanent solo/co-op distinction)?
+	bool isCoopSave() const { return _coop; }
+	void setCoopSave(bool coop) { _coop = coop; }
+	/// Locked co-op player list (host first), set at campaign start.
+	const std::vector<std::string> &getCoopPlayers() const { return _coopPlayers; }
+	void setCoopPlayers(const std::vector<std::string> &players) { _coopPlayers = players; }
+	void addCoopPlayer(const std::string &name)
+	{
+		for (const auto &p : _coopPlayers)
+			if (p == name)
+				return;
+		_coopPlayers.push_back(name);
+	}
 	/// Gets the current funds.
 	int64_t getFunds() const;
 	/// Gets the list of funds from previous months.
@@ -320,6 +339,11 @@ private:
 	SavedBattleGame *getSavedBattle();
 	/// Sets the current battle game.
 	void setBattleGame(SavedBattleGame *battleGame);
+	/// Detach the battle WITHOUT deleting it (PRD-09: serialize a geoscape-only
+	/// coop snapshot). Returns the detached pointer; pair with reattachBattleGame.
+	SavedBattleGame *detachBattleGame() { SavedBattleGame *b = _battleGame; _battleGame = 0; return b; }
+	/// Reattach a battle previously detached (does not delete any current pointer).
+	void reattachBattleGame(SavedBattleGame *battleGame) { _battleGame = battleGame; }
 	/// Sets the status of a ufopedia rule
 	void setUfopediaRuleStatus(const std::string &ufopediaRule, int newStatus);
 	/// Sets the status of a manufacture rule

--- a/tools/coop_test/README.md
+++ b/tools/coop_test/README.md
@@ -65,6 +65,21 @@ campaign each run.
 - `test_server_browser.py` - rendezvous-server combobox state (offline path).
 - `test_ufo_notice.py` - when one player detects a UFO, the peer gets the notice
   too (both `UfoDetectedState` popups); checks both directions.
+- `test_client_zero_disk.py` - host-save authority: after a full session with
+  aggressive autosaves and host/client saves through the real save funnel, the
+  client's user dir contains zero `.sav`/`.asav`/`.data` files (and the host
+  dir no `.data` sidecars - world blobs live in memory + the host .sav embed).
+- `test_new_campaign_flow.py` - redesigned campaign flow e2e: Solo/Co-op New
+  Game split (D1 solo-hosting refusal), host-driven lobby + START CAMPAIGN,
+  parallel base building, coop markers + locked player list.
+- `test_resume_flow.py` - resume e2e: menu load -> host window -> resume
+  lobby, wrong-name refusal, registered client with an empty user dir gets its
+  world back (roster + markers intact).
+- `test_rejoin_flow.py` - mid-session hard-kill -> host freeze dialog ->
+  direct rejoin (no lobby) -> RESUME; roster intact, zero-disk.
+
+`session.py` is the shared campaign dance (`new_campaign` / `resume_campaign`
+/ `assert_client_zero_disk`) used by every test.
 
 `harness.py` is the shared library (not a test).
 
@@ -72,8 +87,12 @@ campaign each run.
 
 - Introspection: `ping`, `get_state`, `get_coop`, `get_soldiers`,
   `get_mirror_soldiers`, `has_coop_file`, `coop_stats`, `set_option`.
-- Session flow: `load_save`, `save_game`, `open_new_game`, `newgame_ok`,
-  `place_first_base`, `profile_ok`, `host_tcp`, `join_tcp`, `lobby_ready`,
+- Session flow: `load_save`, `load_save_menu` (real LoadGameState routing),
+  `save_game`, `save_game_ui` (through the real SaveGameState funnel: `type` =
+  `quick` | `auto_geoscape`), `open_new_game` (`mode`: `solo` | `coop`),
+  `newgame_ok`, `place_first_base`, `profile_ok`, `host_tcp`, `join_tcp`,
+  `lobby_state`, `lobby_start_campaign`, `lobby_resume_campaign`,
+  `coop_dialog_back`, `save_markers`, `lobby_ready` (legacy),
   `client_reload_progress`, `quit`.
 - Transfer / UI: `transfer`, `transfer_targets`, `rename_soldier`,
   `open_soldiers`, `visit_coop_base`, `open_transfer_dialog`, `cancel_dialog`,

--- a/tools/coop_test/scenario_dialog_shot.py
+++ b/tools/coop_test/scenario_dialog_shot.py
@@ -1,0 +1,49 @@
+"""Drive the game to the 'waiting for players to place bases' dialog and
+screenshot it (visual iteration helper for the compact dialog, not a test).
+
+Usage: python tools/coop_test/scenario_dialog_shot.py <out.png>
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
+import session
+
+
+def main(out_png):
+    host = GameClient("host", 48670, make_user_dir("shot_host"))
+    client = GameClient("client", 48671, make_user_dir("shot_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
+        host.wait_for("host lobby", lambda: session._has_state(host, "LobbyMenu"))
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
+        client.wait_for("client lobby", lambda: session._has_state(client, "LobbyMenu"))
+        host.wait_for("eligible", lambda: host.cmd({"cmd": "lobby_state"}).get("startEligible") or None)
+        host.ok({"cmd": "lobby_start_campaign"})
+
+        client.wait_for("client base placement", lambda: session._has_state(client, "BuildNewBaseState"))
+        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
+        client.wait_for(
+            "client waiting dialog",
+            lambda: ("CoopState" in client.cmd({"cmd": "get_state"})["states"][-1]) or None,
+        )
+        time.sleep(1)  # let the popup animation finish
+        client.ok({"cmd": "screenshot", "path": out_png})
+        print("saved:", out_png)
+    finally:
+        host.shutdown()
+        client.shutdown()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/tools/coop_test/session.py
+++ b/tools/coop_test/session.py
@@ -1,0 +1,154 @@
+"""Shared session bring-up for the redesigned co-op campaign flow.
+
+One implementation of the dance, imported by every test (no more copied
+bootstrap code):
+
+  new_campaign(host, client)   - Solo/Co-op dropdown -> difficulty -> host
+                                 window -> lobby -> START CAMPAIGN -> both
+                                 players place bases -> host RESUME ->
+                                 session up on the geoscape.
+  assert_client_zero_disk(dir) - the standing invariant: a co-op client never
+                                 writes save data to disk. Call in teardown.
+
+Ports/base coordinates match the old bootstrap defaults so migrated tests
+behave identically.
+"""
+
+import os
+import time
+
+from harness import LAND_LON, LAND_LAT
+
+HOST_LON, HOST_LAT = 0.35, 0.85
+
+SAVE_EXTS = (".sav", ".asav", ".data")
+
+
+def states(gc):
+    return gc.cmd({"cmd": "get_state"})["states"]
+
+
+def has_state(gc, name):
+    return any(name in s for s in states(gc)) or None
+
+
+# PRD-13 S7: public names; the underscore forms are kept as aliases for any
+# straggler caller and for this module's own internal use below.
+_states = states
+_has_state = has_state
+
+
+def new_campaign(host, client, port="47900",
+                 host_name="HostPlayer", client_name="ClientPlayer",
+                 host_base="HostBase", client_base="ClientBase"):
+    """Bring up a fresh co-op campaign through the redesigned flow."""
+
+    # host: New Game -> Co-op -> difficulty OK (world created, HostMenu opens)
+    host.ok({"cmd": "open_new_game", "mode": "coop"})
+    host.wait_for("difficulty", lambda: _has_state(host, "NewGameState"))
+    host.ok({"cmd": "newgame_ok"})
+    host.wait_for("host window", lambda: _has_state(host, "HostMenu"))
+
+    # host window -> lobby
+    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": port, "player": host_name})
+    host.wait_for("host lobby", lambda: _has_state(host, "LobbyMenu"))
+
+    # client joins and lands in the lobby (no ready button, no Profile)
+    client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": port, "player": client_name})
+    client.wait_for("client lobby", lambda: _has_state(client, "LobbyMenu"))
+
+    # START CAMPAIGN enabled once the client is in
+    host.wait_for(
+        "start eligible",
+        lambda: host.cmd({"cmd": "lobby_state"}).get("startEligible") or None,
+    )
+    host.ok({"cmd": "lobby_start_campaign"})
+
+    # both sides place their first base in their own world
+    host.wait_for("host base placement", lambda: _has_state(host, "BuildNewBaseState"))
+    r = host.cmd({"cmd": "place_first_base", "lon": HOST_LON, "lat": HOST_LAT, "name": host_base})
+    if not r.get("ok"):
+        host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": host_base})
+
+    client.wait_for("client base placement", lambda: _has_state(client, "BuildNewBaseState"))
+    client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": client_base})
+
+    # host holds in the waiting dialog until the client's world blob arrives,
+    # then clicks RESUME
+    host.wait_for(
+        "all players placed bases",
+        lambda: host.cmd({"cmd": "has_coop_file",
+                          "key": f"host_{host.cmd({'cmd': 'save_markers'})['saveID']}_{client_name}.data"}).get("present") or None,
+        timeout=120,
+    )
+    host.ok({"cmd": "coop_dialog_back"})
+
+    # session up: both synced (client received basehost etc.)
+    try:
+        client.wait_for(
+            "session up",
+            lambda: (lambda c: (c.get("lobbyClosed") and c.get("hasSave")) or None)(client.cmd({"cmd": "get_coop"})),
+            timeout=120,
+        )
+    except TimeoutError:
+        print("DEBUG host  get_coop:", host.cmd({"cmd": "get_coop"}))
+        print("DEBUG host  states:  ", host.cmd({"cmd": "get_state"})["states"])
+        print("DEBUG client get_coop:", client.cmd({"cmd": "get_coop"}))
+        print("DEBUG client states: ", client.cmd({"cmd": "get_state"})["states"])
+        raise
+    print("session up (redesigned flow)")
+
+
+def resume_campaign(host, client, save_file, port="47900",
+                    host_name="HostPlayer", client_name="ClientPlayer"):
+    """Resume a co-op campaign save through the redesigned flow: menu load ->
+    host window -> resume lobby (gated on the registered roster) -> RESUME ->
+    world served -> session up. `host` must be freshly at the main menu with
+    the save in its user dir; `client` freshly at the main menu."""
+
+    host.ok({"cmd": "load_save_menu", "file": save_file})
+    host.wait_for("host window (resume)", lambda: _has_state(host, "HostMenu"))
+
+    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": port, "player": host_name})
+    host.wait_for("resume lobby", lambda: _has_state(host, "LobbyMenu"))
+    ls = host.ok({"cmd": "lobby_state"})
+    assert ls["lobbyMode"] == 2, f"expected resume lobby, got {ls}"
+
+    client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": port, "player": client_name})
+    client.wait_for("client resume lobby", lambda: _has_state(client, "LobbyMenu"))
+
+    host.wait_for(
+        "all registered players joined",
+        lambda: (lambda r: r.get("ok") is True or None)(host.cmd({"cmd": "lobby_resume_campaign"})),
+        timeout=60,
+        interval=2.0,
+    )
+
+    # host holds in the loading dialog until the client acks, then RESUME
+    host.wait_for(
+        "client world ack",
+        lambda: host.cmd({"cmd": "get_coop"}).get("resumeAck") or None,
+        timeout=120,
+    )
+    host.ok({"cmd": "coop_dialog_back"})
+
+    client.wait_for(
+        "resume session up",
+        lambda: (lambda c: (c.get("hasSave") and not _has_state(client, "LobbyMenu")) or None)(client.cmd({"cmd": "get_coop"})),
+        timeout=120,
+    )
+    print("session resumed (redesigned flow)")
+
+
+def save_files(user_dir):
+    found = []
+    for root, _dirs, files in os.walk(user_dir):
+        for f in files:
+            if f.lower().endswith(SAVE_EXTS):
+                found.append(os.path.relpath(os.path.join(root, f), user_dir))
+    return sorted(found)
+
+
+def assert_client_zero_disk(client_dir):
+    files = save_files(client_dir)
+    assert files == [], f"CLIENT WROTE SAVE DATA TO DISK: {files}"

--- a/tools/coop_test/test_bug_fixes.py
+++ b/tools/coop_test/test_bug_fixes.py
@@ -15,47 +15,14 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
+import session
 
 HOST_LON, HOST_LAT = 0.35, 0.85
 
 
 def bootstrap_fresh_session(host, client):
-    for gc in (host, client):
-        gc.ok({"cmd": "set_option", "name": "HostSaveProgress", "value": True})
-
-    host.ok({"cmd": "open_new_game"})
-    host.wait_for("difficulty", lambda: any("NewGameState" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-    host.ok({"cmd": "newgame_ok"})
-    host.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-    r = host.cmd({"cmd": "place_first_base", "lon": HOST_LON, "lat": HOST_LAT, "name": "HostBase"})
-    if not r.get("ok"):
-        host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "HostBase"})
-
-    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
-    client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
-    host.wait_for("client joined", lambda: host.cmd({"cmd": "get_coop"}).get("coopStatic") or None)
-
-    host.wait_for("host profile", lambda: any("Profile" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-    host.ok({"cmd": "profile_ok"})
-    client.wait_for("client profile", lambda: any("Profile" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-    client.ok({"cmd": "profile_ok"})
-    client.wait_for("difficulty", lambda: any("NewGameState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-    client.ok({"cmd": "newgame_ok"})
-    client.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-    client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
-
-    client.wait_for("client lobby", lambda: any("LobbyMenu" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-    client.ok({"cmd": "lobby_ready"})
-    host.ok({"cmd": "lobby_ready"})
-    client.wait_for("locked", lambda: client.cmd({"cmd": "get_coop"}).get("sessionLocked") or None, timeout=60)
-    host.ok({"cmd": "lobby_ready"})
-    client.ok({"cmd": "lobby_ready"})
-    client.wait_for(
-        "lobby closed + save synced",
-        lambda: (lambda c: (c.get("lobbyClosed") and c.get("hasSave")) or None)(client.cmd({"cmd": "get_coop"})),
-        timeout=120,
-    )
-    print("session up")
+    """Fresh co-op campaign via the redesigned flow (shared session dance)."""
+    session.new_campaign(host, client)
 
 
 def own_base(gc):

--- a/tools/coop_test/test_client_zero_disk.py
+++ b/tools/coop_test/test_client_zero_disk.py
@@ -1,0 +1,86 @@
+"""Client-zero-disk guarantee: in a coop campaign the CLIENT machine must never
+write save data to disk. The host .sav (with embedded client blobs) is the
+single authority.
+
+Asserts that after a full session -- bring-up, geoscape days passing with
+autosave enabled, an explicit host save through the real SaveGameState funnel,
+and a client save attempt through the same funnel -- the client's user folder
+contains zero *.sav / *.asav / *.data files.
+
+Run:  python tools/coop_test/test_client_zero_disk.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+from test_bug_fixes import bootstrap_fresh_session
+import geo
+import session
+
+# PRD-13 S7: SAVE_EXTS / save_files / the zero-disk assert live in session.py -
+# this test guards the branch's core invariant, so it must use the one true rule
+# (if SAVE_EXTS grows, this test must check the new rule too).
+
+
+def main():
+    host_dir = make_user_dir("zerodisk_host")
+    client_dir = make_user_dir("zerodisk_client")
+    host = GameClient("host", 48610, host_dir)
+    client = GameClient("client", 48611, client_dir)
+    try:
+        host.spawn()
+        client.spawn()
+        host.connect()
+        client.connect()
+
+        bootstrap_fresh_session(host, client)
+        geo.wait_both_ready(host, client)
+
+        # Aggressive autosave settings on BOTH sides: every in-game day on the
+        # geoscape. Today this leaks _autogeo_.asav onto the client; after the
+        # migration the client-side gate must swallow it.
+        for gc in (host, client):
+            gc.ok({"cmd": "set_option", "name": "autosave", "value": True})
+            gc.ok({"cmd": "set_option", "name": "oxceGeoAutosaveFrequency", "value": 1})
+
+        # Let two in-game days pass so the daily autosave trigger fires.
+        geo.skip_ingame_time(host, client, minutes=2 * 24 * 60)
+
+        # Host quicksaves through the real save funnel (SaveGameState): this
+        # is the authoritative save path - it regenerates the saveID, runs the
+        # client-progress pull cycle, and embeds the client world blob.
+        host.ok({"cmd": "save_game_ui", "type": "quick"})
+        host.wait_for(
+            "host quicksave file",
+            lambda: os.path.exists(os.path.join(host_dir, "xcom1", "_quick_.asav")) or None,
+            timeout=60,
+        )
+
+        # Client tries the same funnel; this must be a silent no-op
+        # (no file, no crash).
+        client.ok({"cmd": "save_game_ui", "type": "quick"})
+        client.ok({"cmd": "save_game_ui", "type": "auto_geoscape"})
+        time.sleep(5)  # give a would-be write time to land
+
+        # No geoscape-settle gate here: a UFO detected during the time skip
+        # re-pushes its popup while paused, and the assertions below only
+        # look at the filesystem anyway.
+        host_saves = session.save_files(host_dir)
+        print(f"host save files:   {host_saves}")
+        print(f"client save files: {session.save_files(client_dir)}")
+
+        assert any("_quick_.asav" in f for f in host_saves), \
+            f"host must still save normally, got {host_saves}"
+        session.assert_client_zero_disk(client_dir)
+
+        print("PASS client-zero-disk: host saves normally, client user dir clean")
+    finally:
+        host.shutdown()
+        client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_craft_status_sync.py
+++ b/tools/coop_test/test_craft_status_sync.py
@@ -32,7 +32,7 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import GameClient, make_user_dir, TEST_ROOT, LAND_LON, LAND_LAT
 # Reuse the known-good fresh-coop bring-up from the geoscape-sync test.
-from test_geoscape_sync import bringup, states, HOST_LON, HOST_LAT
+from test_geoscape_sync import bringup, HOST_LON, HOST_LAT  # PRD-13 S7: local `states` removed (was unused here)
 
 # Mission site + UFO placed FAR from the host base so a dispatched craft is
 # perpetually en route (never arrives -> never triggers ConfirmLanding / a

--- a/tools/coop_test/test_geoscape_sync.py
+++ b/tools/coop_test/test_geoscape_sync.py
@@ -35,6 +35,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import GameClient, make_user_dir, TEST_ROOT, LAND_LON, LAND_LAT
+import session
 from geo import (wait_both_ready, drain_popups, on_geoscape, top_state,
                  TimeWatchdog, game_minutes, StuckDialogError)
 
@@ -52,56 +53,17 @@ def keep_awake():
         ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED)
 
 
-def states(gc):
-    return gc.cmd({"cmd": "get_state"})["states"]
-
-
 def on_geo(gc):
-    st = states(gc)
+    st = session.states(gc)
     return "GeoscapeState" in st[-1]
 
 
 def bringup(host, client):
     """Full fresh-coop dance to a live geoscape with both bases placed + save
-    synced. Lifted from test_transfer_fresh.py (the known-good path)."""
+    synced, via the redesigned campaign flow (session.new_campaign)."""
     host.spawn(); client.spawn()
     host.connect(timeout=240); client.connect(timeout=240)
-    for gc in (host, client):
-        gc.ok({"cmd": "set_option", "name": "HostSaveProgress", "value": True})
-
-    host.ok({"cmd": "open_new_game"})
-    host.wait_for("difficulty", lambda: any("NewGameState" in s for s in states(host)) or None)
-    host.ok({"cmd": "newgame_ok"})
-    host.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in states(host)) or None)
-    r = host.cmd({"cmd": "place_first_base", "lon": HOST_LON, "lat": HOST_LAT, "name": "HostBase"})
-    if not r.get("ok"):
-        host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "HostBase"})
-    host.wait_for("host on geoscape", lambda: on_geo(host) and len(states(host)) == 1 or None)
-
-    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
-    client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
-    host.wait_for("client joined", lambda: host.cmd({"cmd": "get_coop"}).get("coopStatic") or None)
-
-    host.wait_for("host profile", lambda: any("Profile" in s for s in states(host)) or None)
-    host.ok({"cmd": "profile_ok"})
-    client.wait_for("client profile", lambda: any("Profile" in s for s in states(client)) or None)
-    client.ok({"cmd": "profile_ok"})
-
-    client.wait_for("difficulty", lambda: any("NewGameState" in s for s in states(client)) or None)
-    client.ok({"cmd": "newgame_ok"})
-    client.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in states(client)) or None)
-    client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
-
-    client.wait_for("client lobby", lambda: any("LobbyMenu" in s for s in states(client)) or None)
-    client.ok({"cmd": "lobby_ready"})
-    host.ok({"cmd": "lobby_ready"})
-    client.wait_for("locked", lambda: client.cmd({"cmd": "get_coop"}).get("sessionLocked") or None, timeout=60)
-    host.ok({"cmd": "lobby_ready"})
-    client.ok({"cmd": "lobby_ready"})
-    client.wait_for(
-        "lobby closed + save synced",
-        lambda: (lambda c: (c.get("lobbyClosed") and c.get("hasSave")) or None)(client.cmd({"cmd": "get_coop"})),
-        timeout=120)
+    session.new_campaign(host, client)
 
 
 def ping_rtt_ms(gc):

--- a/tools/coop_test/test_lobby_dialogs.py
+++ b/tools/coop_test/test_lobby_dialogs.py
@@ -1,0 +1,189 @@
+"""Regression tests for five co-op dialog bugs:
+
+1. Host new game -> client joins lobby -> client disconnects -> the client must
+   NOT be left staring at a lingering "Connecting..." wait dialog (CoopState 15)
+   that was buried under the lobby and never popped.
+2. New game, all bases placed: the host dialog must read "All bases placed." with
+   a "BEGIN" button (was "All players connected" / "RESUME").
+3. The host's "waiting for bases" dialog must use the SAME message and compact
+   scaling as the client's hold dialog (was a big, poorly-scaled window).
+4. A rejoining client must hold with "Waiting for host to resume the game." (was
+   the fresh-placement message "Waiting for all players to place their bases...").
+5. The "Waiting for <player> to reconnect" freeze dialog must be compact (~30% of
+   the old height), not a huge window.
+
+Dialog introspection uses the coop_dialog_info harness command (code / title /
+back-button text+visibility / window height).
+
+Run:  python tools/coop_test/test_lobby_dialogs.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
+import session
+
+HOST_LON, HOST_LAT = 0.35, 0.85
+
+WAIT_BASES_MSG = "Waiting for all players\nto place their bases..."
+RESUME_HOLD_MSG = "Waiting for host to resume the game."
+
+
+def dlg(gc):
+    return gc.cmd({"cmd": "coop_dialog_info"})
+
+
+def _host_lobby(host, port):
+    host.ok({"cmd": "open_new_game", "mode": "coop"})
+    host.wait_for("difficulty", lambda: session.has_state(host, "NewGameState"))
+    host.ok({"cmd": "newgame_ok"})
+    host.wait_for("host window", lambda: session.has_state(host, "HostMenu"))
+    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": port, "player": "HostPlayer"})
+    host.wait_for("host lobby", lambda: session.has_state(host, "LobbyMenu"))
+
+
+def _campaign_lobby(host, client, port):
+    """Host opens a co-op lobby; the client joins it (plain campaign join)."""
+    _host_lobby(host, port)
+    client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": port, "player": "ClientPlayer"})
+    client.wait_for("client lobby", lambda: session.has_state(client, "LobbyMenu"))
+
+
+# ---------------------------------------------------------------- bug 1
+def test_connecting_dialog_cleared():
+    host = GameClient("host", 48720, make_user_dir("dlg1_host"))
+    client = GameClient("client", 48721, make_user_dir("dlg1_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        # The real join flow: the client has its own world and browses servers,
+        # so a ServerList sits under the "Connecting..." dialog and the lobby.
+        client.ok({"cmd": "open_new_game", "mode": "solo"})
+        client.wait_for("client difficulty", lambda: session.has_state(client, "NewGameState"))
+        client.ok({"cmd": "newgame_ok"})
+        client.wait_for("client base", lambda: session.has_state(client, "BuildNewBaseState"))
+        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "SoloBase"})
+        client.ok({"cmd": "open_server_browser"})
+        client.wait_for("client browser", lambda: session.has_state(client, "ServerList"))
+
+        _host_lobby(host, "47910")
+
+        # mirror ServerList/DirectConnect: push the "Connecting..." dialog, join
+        client.ok({"cmd": "coop_push_connecting"})
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47910", "player": "ClientPlayer"})
+        client.wait_for("client lobby", lambda: session.has_state(client, "LobbyMenu"))
+
+        # client leaves the lobby -> must not resurface a buried "Connecting..."
+        client.ok({"cmd": "lobby_disconnect"})
+        time.sleep(3)  # let the client's think()/teardown settle
+
+        d = dlg(client)
+        assert not (d.get("present") and d.get("code") == 15), \
+            f"BUG1: stale Connecting... dialog after lobby disconnect: {d}"
+        assert "Connecting" not in (d.get("title") or ""), \
+            f"BUG1: Connecting text still showing: {d}"
+        print("PASS bug1: no lingering Connecting... after lobby disconnect")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+# ---------------------------------------------------------------- bugs 2 + 3
+def test_wait_bases_dialog():
+    host = GameClient("host", 48722, make_user_dir("dlg2_host"))
+    client = GameClient("client", 48723, make_user_dir("dlg2_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        _campaign_lobby(host, client, "47911")
+
+        host.wait_for("start eligible",
+                      lambda: host.cmd({"cmd": "lobby_state"}).get("startEligible") or None)
+        host.ok({"cmd": "lobby_start_campaign"})
+
+        # host places first, then sits in WAIT_BASES waiting for the client
+        host.wait_for("host base placement", lambda: session.has_state(host, "BuildNewBaseState"))
+        r = host.cmd({"cmd": "place_first_base", "lon": HOST_LON, "lat": HOST_LAT, "name": "HostBase"})
+        if not r.get("ok"):
+            host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "HostBase"})
+
+        # bug 3: while waiting, same message + compact window as the client hold
+        host.wait_for("host wait-bases dialog",
+                      lambda: (dlg(host).get("code") == 60) or None,
+                      timeout=60)
+        hd = dlg(host)
+        assert hd["code"] == 60, f"BUG3: expected WAIT_BASES(60): {hd}"
+        assert hd["title"] == WAIT_BASES_MSG, f"BUG3: host message mismatch: {hd!r}"
+        assert not hd["backVisible"], f"BUG3: button visible while still waiting: {hd}"
+        assert hd["windowHeight"] <= 80, f"BUG3: host wait dialog not compact: {hd}"
+        print(f"PASS bug3: host wait-bases matches client message, compact (h={hd['windowHeight']})")
+
+        # the client, having placed, holds with the SAME message (proves reuse)
+        client.wait_for("client base placement", lambda: session.has_state(client, "BuildNewBaseState"))
+        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
+        client.wait_for("client hold", lambda: (dlg(client).get("code") == 65) or None, timeout=60)
+        cd = dlg(client)
+        assert cd["title"] == WAIT_BASES_MSG, f"BUG3: client hold message drifted: {cd!r}"
+
+        # bug 2: once all bases arrive, host flips to "All bases placed." / BEGIN
+        host.wait_for("all bases placed", lambda: (dlg(host).get("backVisible")) or None, timeout=120)
+        hd = dlg(host)
+        assert hd["title"] == "All bases placed.", f"BUG2: title wrong: {hd!r}"
+        assert hd["backText"] == "BEGIN", f"BUG2: button wrong: {hd!r}"
+        print("PASS bug2: all-bases-placed reads 'All bases placed.' / BEGIN")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+# ---------------------------------------------------------------- bugs 4 + 5
+def test_rejoin_hold_and_freeze():
+    host = GameClient("host", 48724, make_user_dir("dlg4_host"))
+    client = GameClient("client", 48725, make_user_dir("dlg4_client"))
+    client2 = None
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client, port="47912")
+
+        # hard-kill the client mid-session
+        client.proc.kill(); client.proc.wait(timeout=10)
+
+        # bug 5: host freezes in a compact "waiting to reconnect" dialog
+        host.wait_for("host freeze dialog", lambda: (dlg(host).get("code") == 64) or None, timeout=60)
+        fd = dlg(host)
+        assert fd["code"] == 64, f"BUG5: expected FREEZE(64): {fd}"
+        assert "to reconnect" in fd["title"], f"BUG5: wrong freeze text: {fd!r}"
+        assert fd["windowHeight"] <= 60, f"BUG5: freeze dialog too tall (h={fd['windowHeight']}): {fd}"
+        print(f"PASS bug5: freeze dialog compact (h={fd['windowHeight']})")
+
+        # registered client rejoins from a fresh process + empty dir
+        client2 = GameClient("client", 48726, make_user_dir("dlg4_client2"))
+        client2.spawn(); client2.connect()
+        client2.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47912", "player": "ClientPlayer"})
+
+        # bug 4: after loading its world, the client holds with the resume message
+        client2.wait_for("client resume hold",
+                         lambda: (dlg(client2).get("code") == 68) or None, timeout=120)
+        cd = dlg(client2)
+        assert cd["title"] == RESUME_HOLD_MSG, f"BUG4: wrong rejoin hold message: {cd!r}"
+        print("PASS bug4: rejoin hold reads 'Waiting for host to resume the game.'")
+    finally:
+        host.shutdown(); client.shutdown()
+        if client2:
+            client2.shutdown()
+
+
+def main():
+    test_connecting_dialog_cleared()
+    test_wait_bases_dialog()
+    test_rejoin_hold_and_freeze()
+    print("ALL LOBBY DIALOG TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_lobby_gating.py
+++ b/tools/coop_test/test_lobby_gating.py
@@ -1,0 +1,180 @@
+"""Regression tests for two lobby/base-building gating bugs:
+
+1. START CAMPAIGN must be ineligible while the host is ALONE in the lobby
+   (was: onConnect==1 as soon as the host listens, so a lone host could
+   start).
+2. The player who places their base FIRST must hold in a
+   "Waiting for all players to place their bases..." dialog with frozen
+   time until the host resumes (was: the client landed on a live, ticking
+   geoscape while the host was still placing).
+
+Run:  python tools/coop_test/test_lobby_gating.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
+import session
+import geo  # PRD-13 S7: geo.top_state (safe on empty stack)
+
+
+def client_clock(gc):
+    r = gc.cmd({"cmd": "geo_state"})
+    if not r.get("ok"):
+        return None
+    t = r["time"]
+    return (t["year"], t["month"], t["day"], t["hour"], t["minute"])
+
+
+def main():
+    host = GameClient("host", 48650, make_user_dir("gating_host"))
+    client = GameClient("client", 48651, make_user_dir("gating_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        # --- Bug 1: lone host must not be able to START ---
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
+        host.wait_for("host lobby", lambda: session._has_state(host, "LobbyMenu"))
+
+        # give the host thread time to settle in its (empty) listening state
+        time.sleep(3)
+        ls = host.ok({"cmd": "lobby_state"})
+        assert not ls["startEligible"], f"BUG1: lone host is start-eligible: {ls}"
+        r = host.cmd({"cmd": "lobby_start_campaign"})
+        assert not r.get("ok"), f"BUG1: lone host could START CAMPAIGN: {r}"
+        print("PASS bug1: lone host cannot start the campaign")
+
+        # --- Bug 2: first placer waits with frozen time ---
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
+        client.wait_for("client lobby", lambda: session._has_state(client, "LobbyMenu"))
+        host.wait_for(
+            "start eligible with client",
+            lambda: host.cmd({"cmd": "lobby_state"}).get("startEligible") or None,
+        )
+        host.ok({"cmd": "lobby_start_campaign"})
+
+        # CLIENT places first, before the host
+        client.wait_for("client base placement", lambda: session._has_state(client, "BuildNewBaseState"))
+        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
+
+        # the client must be held in a waiting dialog, not on a live geoscape
+        client.wait_for(
+            "client waiting dialog",
+            lambda: ("CoopState" in geo.top_state(client)) or None,
+            timeout=30,
+        )
+        print("PASS bug2a: first placer holds in the waiting dialog")
+
+        # and its clock must not advance while waiting
+        t0 = client_clock(client)
+        time.sleep(5)
+        t1 = client_clock(client)
+        if t0 != t1:
+            print("DEBUG client states:", client.cmd({"cmd": "get_state"})["states"])
+            print("DEBUG host   states:", host.cmd({"cmd": "get_state"})["states"])
+        assert t0 == t1, f"BUG2: client clock advanced while waiting: {t0} -> {t1}"
+        print("PASS bug2b: client clock frozen while waiting")
+
+        # host places, waits for the blob, resumes
+        host.wait_for("host base placement", lambda: session._has_state(host, "BuildNewBaseState"))
+        r = host.cmd({"cmd": "place_first_base", "lon": 0.35, "lat": 0.85, "name": "HostBase"})
+        if not r.get("ok"):
+            host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "HostBase"})
+        host.wait_for(
+            "all players placed",
+            lambda: host.cmd({"cmd": "has_coop_file",
+                              "key": f"host_{host.cmd({'cmd': 'save_markers'})['saveID']}_ClientPlayer.data"}).get("present") or None,
+            timeout=120,
+        )
+        host.ok({"cmd": "coop_dialog_back"})
+
+        # the client's waiting dialog must clear and the session comes up
+        client.wait_for(
+            "client released to geoscape",
+            lambda: ("GeoscapeState" in geo.top_state(client)) or None,
+            timeout=60,
+        )
+        client.wait_for(
+            "session up",
+            lambda: (lambda c: (c.get("lobbyClosed") and c.get("hasSave")) or None)(client.cmd({"cmd": "get_coop"})),
+            timeout=120,
+        )
+        print("PASS bug2c: RESUME releases the waiting player, session up")
+
+        session.assert_client_zero_disk(client.user_dir)
+
+        # --- C4 (PRD-10): client drop while the confirm dialog is open ---
+        # A client leaving after the host opens the START CAMPAIGN confirm
+        # dialog must (a) auto-dismiss the dialog and (b) never start the
+        # campaign, even if the host clicks OK. Drives the REAL confirm dialog.
+        host.shutdown(); client.shutdown()
+        c4_host_dir = make_user_dir("c4_host")
+        host = GameClient("host", 48652, c4_host_dir)
+        client = GameClient("client", 48653, make_user_dir("c4_client"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47901", "player": "HostPlayer"})
+        host.wait_for("host lobby", lambda: session._has_state(host, "LobbyMenu"))
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47901", "player": "ClientPlayer"})
+        client.wait_for("client lobby", lambda: session._has_state(client, "LobbyMenu"))
+        host.wait_for(
+            "start eligible with client",
+            lambda: host.cmd({"cmd": "lobby_state"}).get("startEligible") or None,
+        )
+
+        # open the REAL confirm dialog (not the startCampaign bypass)
+        host.ok({"cmd": "lobby_start_campaign", "confirm": "dialog"})
+        host.wait_for(
+            "confirm dialog up",
+            lambda: ("ConfirmStartCampaignState" in geo.top_state(host)) or None,
+            timeout=15,
+        )
+
+        # hard-kill the lone client (abrupt drop, no graceful quit)
+        client.proc.kill()
+
+        # (a) the dialog auto-dismisses once the host notices the drop
+        host.wait_for(
+            "confirm dialog auto-dismissed",
+            lambda: ("ConfirmStartCampaignState" not in geo.top_state(host)) or None,
+            timeout=30,
+        )
+        assert not host.cmd({"cmd": "lobby_state"}).get("startEligible"), \
+            "C4: host still start-eligible after the lone client left"
+        print("PASS C4a: confirm dialog auto-dismissed on client drop")
+
+        # (b) clicking OK now must not start the campaign (dialog gone -> no-op;
+        # and even had it lingered, btnOkClick re-checks eligibility)
+        host.ok({"cmd": "lobby_confirm_ok"})
+        time.sleep(2)
+        ls = host.ok({"cmd": "lobby_state"})
+        assert ls.get("lobbyOpen") and ls.get("lobbyMode") == 1 and not ls.get("sessionLocked"), \
+            f"C4: campaign started after client left (lobby_state={ls})"
+        markers = host.cmd({"cmd": "save_markers"})
+        assert not markers.get("coopPlayers"), \
+            f"C4: roster locked with a departed player: {markers}"
+        assert not os.path.exists(os.path.join(c4_host_dir, "xcom1", "_autogeo_.asav")), \
+            "C4: _autogeo_.asav written despite the aborted start"
+        print("PASS C4b: client drop before OK does not start the campaign")
+
+        print("ALL LOBBY GATING TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_lobby_polish.py
+++ b/tools/coop_test/test_lobby_polish.py
@@ -1,0 +1,132 @@
+"""Regression tests for four lobby/flow polish bugs:
+
+2. HostMenu CANCEL during a co-op campaign must return to the MAIN MENU,
+   not drop the host onto a live solo geoscape.
+3. Host disconnect from a resume lobby + re-host must land back in a
+   RESUME lobby (was: lobbyMode reset -> legacy READY-dance lobby).
+4. Dismissing "You are not a player in this campaign." must also clear the
+   "Connecting..." dialog left underneath.
+5. A refused (wrong-name) join attempt must be invisible to the host: no
+   roster entry, no "... has left the server" popup.
+
+Run:  python tools/coop_test/test_lobby_polish.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+import geo  # PRD-13 S7: geo.top_state (safe on empty stack)
+
+SAVE = "polish_e2e.sav"
+
+
+def main():
+    host_dir = make_user_dir("polish_host")
+    host = GameClient("host", 48660, host_dir)
+    client = GameClient("client", 48661, make_user_dir("polish_client"))
+    imposter = None
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        # --- Bug 2: HostMenu cancel -> main menu ---
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_menu_cancel"})
+        host.wait_for("main menu after cancel", lambda: ("MainMenuState" in geo.top_state(host)) or None, timeout=30)
+        assert not session._has_state(host, "GeoscapeState"), \
+            f"BUG2: host still has a live world after cancel: {host.cmd({'cmd': 'get_state'})['states']}"
+        print("PASS bug2: host-window cancel returns to the main menu")
+
+        # --- set up a campaign + save for the remaining bugs ---
+        session.new_campaign(host, client)
+        host.ok({"cmd": "save_game_ui", "type": "quick"})
+        host.wait_for(
+            "host quicksave",
+            lambda: os.path.exists(os.path.join(host_dir, "xcom1", "_quick_.asav")) or None,
+            timeout=60,
+        )
+        host.ok({"cmd": "save_game", "file": SAVE})
+        host.shutdown(); client.shutdown()
+
+        host = GameClient("host", 48662, host_dir)
+        host.spawn(); host.connect()
+        host.ok({"cmd": "load_save_menu", "file": SAVE})
+        host.wait_for("host window (resume)", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
+        host.wait_for("resume lobby", lambda: session._has_state(host, "LobbyMenu"))
+        assert host.ok({"cmd": "lobby_state"})["lobbyMode"] == 2
+
+        # --- Bug 3: disconnect + re-host must stay a RESUME lobby, no READY ---
+        host.ok({"cmd": "lobby_disconnect"})
+        host.wait_for("back at host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47901", "player": "HostPlayer"})
+        host.wait_for("second lobby", lambda: session._has_state(host, "LobbyMenu"))
+        ls = host.ok({"cmd": "lobby_state"})
+        assert ls["lobbyMode"] == 2, f"BUG3: re-hosted lobby lost resume mode: {ls}"
+        assert "READY" not in ls.get("buttonText", ""), f"BUG3: READY button in campaign lobby: {ls}"
+        print("PASS bug3: re-hosted lobby stays in resume mode, no READY button")
+
+        # --- Bug 2b: disconnect -> host window -> CANCEL must also reach the
+        # main menu (the disconnect cleanup used to wipe the mode the cancel
+        # routing keyed on) ---
+        host.ok({"cmd": "lobby_disconnect"})
+        host.wait_for("host window after disconnect", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_menu_cancel"})
+        host.wait_for("main menu after disconnect+cancel", lambda: ("MainMenuState" in geo.top_state(host)) or None, timeout=30)
+        assert not session._has_state(host, "GeoscapeState"), \
+            f"BUG2b: host on a live world after disconnect+cancel: {host.cmd({'cmd': 'get_state'})['states']}"
+        print("PASS bug2b: disconnect + cancel also returns to the main menu")
+
+        # bring the lobby back for the remaining scenarios (fresh port - the
+        # previous one may still be in TIME_WAIT)
+        host.ok({"cmd": "load_save_menu", "file": SAVE})
+        host.wait_for("host window again", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47902", "player": "HostPlayer"})
+        host.wait_for("lobby again", lambda: session._has_state(host, "LobbyMenu"))
+
+        # --- Bugs 4+5: refused joiner ---
+        imposter = GameClient("client", 48663, make_user_dir("polish_imposter"))
+        imposter.spawn(); imposter.connect()
+        imposter.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47902", "player": "Imposter"})
+        # (port 47902 is the re-hosted lobby from the bug-2b recovery above)
+        imposter.wait_for(
+            "refusal dialog",
+            lambda: ("CoopState" in geo.top_state(imposter)) or None,
+            timeout=60,
+        )
+
+        # Bug 5: watch the host for ~6s - no roster entry, no popup
+        deadline = time.time() + 6
+        while time.time() < deadline:
+            ls = host.ok({"cmd": "lobby_state"})
+            players = ls.get("players", [])
+            assert not any("Imposter" in p for p in players), f"BUG5: imposter in roster: {players}"
+            t = geo.top_state(host)
+            assert "LobbyMenu" in t, f"BUG5: popup appeared on host after refused join: {t}"
+            time.sleep(0.5)
+        print("PASS bug5: refused join invisible to the host (no roster entry, no popup)")
+
+        # Bug 4: dismissing the refusal dialog must clear everything behind it
+        imposter.ok({"cmd": "coop_dialog_back"})
+        time.sleep(2)
+        t = geo.top_state(imposter)
+        assert "CoopState" not in t, f"BUG4: dialog left behind after dismissing refusal: {t}"
+        print("PASS bug4: refusal dismissal leaves no stray dialog")
+
+        print("ALL LOBBY POLISH TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+        if imposter:
+            imposter.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_new_campaign_flow.py
+++ b/tools/coop_test/test_new_campaign_flow.py
@@ -1,0 +1,77 @@
+"""End-to-end smoke test of the redesigned co-op campaign flow (F2):
+
+New Game -> Co-op -> host window -> lobby (client has no ready button) ->
+START CAMPAIGN (host, needs >= 1 client) -> both place bases -> host waits
+for every player -> RESUME -> geoscape session.
+
+Also asserts:
+  - the save carries the coop marker + locked player list
+  - START is refused with an empty lobby
+  - a solo campaign cannot be hosted (D1)
+  - the client user dir stays free of save data
+
+Run:  python tools/coop_test/test_new_campaign_flow.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+
+def main():
+    host_dir = make_user_dir("newflow_host")
+    client_dir = make_user_dir("newflow_client")
+    host = GameClient("host", 48620, host_dir)
+    client = GameClient("client", 48621, client_dir)
+    try:
+        host.spawn()
+        client.spawn()
+        host.connect()
+        client.connect()
+
+        # D1: a solo campaign cannot be hosted
+        host.ok({"cmd": "open_new_game", "mode": "solo"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        r = host.cmd({"cmd": "host_tcp", "server": "X", "port": "48700", "player": "H"})
+        assert not r.get("ok") and "solo" in r.get("error", ""), f"solo hosting must be refused, got {r}"
+        print("PASS D1: solo campaign hosting refused")
+
+        # restart cleanly for the real flow
+        host.shutdown()
+        host = GameClient("host", 48622, make_user_dir("newflow_host2"))
+        host.spawn()
+        host.connect()
+
+        session.new_campaign(host, client)
+
+        # markers: coop flag + locked player list on both worlds
+        hm = host.ok({"cmd": "save_markers"})
+        cm = client.ok({"cmd": "save_markers"})
+        assert hm["coop"] is True, f"host save must be coop-marked: {hm}"
+        assert cm["coop"] is True, f"client save must be coop-marked: {cm}"
+        assert hm["coopPlayers"] == ["HostPlayer", "ClientPlayer"], f"host player list wrong: {hm}"
+        assert cm["coopPlayers"] == ["HostPlayer", "ClientPlayer"], f"client player list wrong: {cm}"
+        print("PASS markers: coop + locked player list on both worlds")
+
+        # both on geoscape with their own base
+        hs = host.ok({"cmd": "get_soldiers"})
+        cs = client.ok({"cmd": "get_soldiers"})
+        assert any(b["soldiers"] for b in hs["bases"]), "host has no manned base"
+        assert any(b["soldiers"] for b in cs["bases"]), "client has no manned base"
+        print("PASS worlds: both players landed on the geoscape with a base")
+
+        session.assert_client_zero_disk(client_dir)
+        print("PASS zero-disk: client user dir clean")
+
+        print("ALL NEW-CAMPAIGN FLOW TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_rejoin_flow.py
+++ b/tools/coop_test/test_rejoin_flow.py
@@ -1,0 +1,81 @@
+"""Mid-session disconnect + rejoin (F4/D5):
+
+1. Fresh campaign up (redesigned flow).
+2. Client process is HARD-KILLED mid-geoscape.
+3. Host freezes in a 'Waiting for <name> to reconnect...' dialog.
+4. A fresh client process (empty user dir) reconnects with the registered
+   name, is served its world directly (no lobby), acks, host clicks RESUME.
+5. Session is live again; client roster survived; zero-disk holds.
+
+Run:  python tools/coop_test/test_rejoin_flow.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+
+def main():
+    host_dir = make_user_dir("rejoin_host")
+    host = GameClient("host", 48640, host_dir)
+    client = GameClient("client", 48641, make_user_dir("rejoin_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client)
+
+        before = client.ok({"cmd": "get_soldiers"})
+        own_before = sorted(s["name"] for b in before["bases"] if not b["coopBaseFlag"] for s in b["soldiers"])
+
+        # hard-kill the client mid-session (no clean quit)
+        client.proc.kill()
+        client.proc.wait(timeout=10)
+
+        # host must freeze in the reconnect dialog
+        host.wait_for(
+            "host freeze dialog",
+            lambda: (lambda st: ("CoopState" in st[-1]) or None)(host.cmd({"cmd": "get_state"})["states"]),
+            timeout=60,
+        )
+        print("PASS freeze: host waiting for the dropped player")
+
+        # registered client rejoins from a fresh process + empty dir
+        client = GameClient("client", 48642, make_user_dir("rejoin_client2"))
+        client.spawn(); client.connect()
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
+
+        # host: world served, ack arrives, RESUME
+        host.wait_for(
+            "rejoined client world ack",
+            lambda: host.cmd({"cmd": "get_coop"}).get("resumeAck") or None,
+            timeout=120,
+        )
+        host.ok({"cmd": "coop_dialog_back"})
+
+        client.wait_for(
+            "client back on geoscape",
+            lambda: (lambda c: (c.get("hasSave") and c.get("coopStatic")) or None)(client.cmd({"cmd": "get_coop"})),
+            timeout=120,
+        )
+
+        after = client.ok({"cmd": "get_soldiers"})
+        own_after = sorted(s["name"] for b in after["bases"] if not b["coopBaseFlag"] for s in b["soldiers"])
+        assert own_after == own_before, f"client roster changed across rejoin: {own_before} -> {own_after}"
+        print("PASS rejoin: world served directly, roster intact")
+
+        session.assert_client_zero_disk(client.user_dir)
+        print("PASS zero-disk: rejoined client user dir clean")
+
+        print("ALL REJOIN FLOW TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_resume_flow.py
+++ b/tools/coop_test/test_resume_flow.py
@@ -1,0 +1,122 @@
+"""End-to-end test of the co-op RESUME flow (F3):
+
+1. Bring up a fresh campaign (redesigned flow), host saves, both quit.
+2. Host reloads the save from the menu -> host window -> resume lobby.
+3. A WRONG-named client is refused at the door (roster gate).
+4. The registered client joins, RESUME serves its world, session is up and
+   the client's roster survived the round trip.
+5. Client user dir stays free of save data throughout.
+
+Run:  python tools/coop_test/test_resume_flow.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+SAVE = "resume_e2e.sav"
+
+
+def main():
+    host_dir = make_user_dir("resume_host")
+    client_dir = make_user_dir("resume_client")
+    host = GameClient("host", 48630, host_dir)
+    client = GameClient("client", 48631, client_dir)
+    imposter = None
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client)
+
+        # remember the client's soldiers to verify the resume round trip
+        before = client.ok({"cmd": "get_soldiers"})
+        own_before = sorted(s["name"] for b in before["bases"] if not b["coopBaseFlag"] for s in b["soldiers"])
+        assert own_before, "client should own soldiers before the save"
+
+        # host saves (real funnel: pulls fresh client progress + embeds it)
+        host.ok({"cmd": "save_game_ui", "type": "quick"})
+        host.wait_for(
+            "host quicksave on disk",
+            lambda: os.path.exists(os.path.join(host_dir, "xcom1", "_quick_.asav")) or None,
+            timeout=60,
+        )
+        host.ok({"cmd": "save_game", "file": SAVE})
+
+        # both sessions down
+        host.shutdown(); client.shutdown()
+
+        # host reloads the save through the menu (fresh process, same dir)
+        host = GameClient("host", 48632, host_dir)
+        host.spawn(); host.connect()
+
+        host.ok({"cmd": "load_save_menu", "file": SAVE})
+        host.wait_for("host window (resume)", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
+        host.wait_for("resume lobby", lambda: session._has_state(host, "LobbyMenu"))
+        ls = host.ok({"cmd": "lobby_state"})
+        assert ls["lobbyMode"] == 2, f"expected resume lobby, got {ls}"
+
+        # wrong name refused at the door
+        imposter = GameClient("client", 48633, make_user_dir("resume_imposter"))
+        imposter.spawn(); imposter.connect()
+        imposter.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "Imposter"})
+        imposter.wait_for(
+            "imposter refused",
+            lambda: any("CoopState" in s for s in imposter.cmd({"cmd": "get_state"})["states"]) or None,
+            timeout=60,
+        )
+        r = imposter.cmd({"cmd": "get_coop"})
+        assert not r.get("coopStatic"), f"imposter must not enter the session: {r}"
+        print("PASS roster gate: wrong name refused")
+        imposter.shutdown(); imposter = None
+
+        # registered client rejoins (fresh process, EMPTY user dir)
+        client = GameClient("client", 48634, make_user_dir("resume_client2"))
+        client.spawn(); client.connect()
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
+        client.wait_for("client resume lobby", lambda: session._has_state(client, "LobbyMenu"))
+
+        host.wait_for(
+            "resume accepted",
+            lambda: (lambda rr: rr.get("ok") is True or None)(host.cmd({"cmd": "lobby_resume_campaign"})),
+            timeout=60, interval=2.0,
+        )
+        host.wait_for(
+            "client world ack",
+            lambda: host.cmd({"cmd": "get_coop"}).get("resumeAck") or None,
+            timeout=120,
+        )
+        host.ok({"cmd": "coop_dialog_back"})
+
+        client.wait_for(
+            "resume session up",
+            lambda: (lambda c: (c.get("hasSave") and not session._has_state(client, "LobbyMenu")) or None)(client.cmd({"cmd": "get_coop"})),
+            timeout=120,
+        )
+
+        after = client.ok({"cmd": "get_soldiers"})
+        own_after = sorted(s["name"] for b in after["bases"] if not b["coopBaseFlag"] for s in b["soldiers"])
+        assert own_after == own_before, f"client roster changed across resume: {own_before} -> {own_after}"
+        print("PASS resume: client world restored from the host save (roster intact)")
+
+        cm = client.ok({"cmd": "save_markers"})
+        assert cm["coop"] is True and cm["coopPlayers"] == ["HostPlayer", "ClientPlayer"], f"markers lost: {cm}"
+        print("PASS markers survived the round trip")
+
+        session.assert_client_zero_disk(client.user_dir)
+        print("PASS zero-disk: resumed client user dir clean")
+
+        print("ALL RESUME FLOW TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+        if imposter:
+            imposter.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_session_hardening.py
+++ b/tools/coop_test/test_session_hardening.py
@@ -1,0 +1,329 @@
+"""Regression tests for six session-hardening bugs:
+
+1. Repeated host/disconnect (UDP-public path) could leave a HostMenu with
+   every control hidden (blank window with just CANCEL).
+2. The joining client could not see the host in the lobby roster.
+3. After a disconnect the client's lobby think() stacked a SECOND server
+   browser on top of the old one (CANCEL then acted on the stale copy).
+4. A different player name must never host a campaign save (host identity
+   is locked to coopPlayers[0]).
+5. The resume lobby's waiting text must merge names + port:
+   "Waiting for <names> on port <X>".
+6. A joiner may not take a name already in use (the host's own name passes
+   the roster check - both players ended up as the same identity).
+
+Run:  python tools/coop_test/test_session_hardening.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
+import session
+import geo  # PRD-13 S7: geo.top_state (safe on empty stack) + session.states
+
+SAVE = "hardening_e2e.sav"
+
+
+def main():
+    host_dir = make_user_dir("hard_host")
+    host = GameClient("host", 48680, host_dir)
+    client = GameClient("client", 48681, make_user_dir("hard_client"))
+    joiner = None
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        # ---------- Bug 2: client sees the host in the lobby ----------
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
+        host.wait_for("host lobby", lambda: session._has_state(host, "LobbyMenu"))
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
+        client.wait_for("client lobby", lambda: session._has_state(client, "LobbyMenu"))
+
+        client.wait_for(
+            "host visible in client roster",
+            lambda: any("HostPlayer" in p for p in client.ok({"cmd": "lobby_state"}).get("players", [])) or None,
+            timeout=30,
+        )
+        print("PASS bug2: client sees the host in the lobby roster")
+
+        # ---------- Bug 3: no stacked server browser after disconnect ----------
+        # Fresh client WITH its own solo world (ServerList needs one), browser
+        # under the lobby like the real join flow.
+        host.shutdown(); client.shutdown()
+        host = GameClient("host", 48686, make_user_dir("hard_host3"))
+        client = GameClient("client", 48687, make_user_dir("hard_client3"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        client.ok({"cmd": "open_new_game", "mode": "solo"})
+        client.wait_for("client difficulty", lambda: session._has_state(client, "NewGameState"))
+        client.ok({"cmd": "newgame_ok"})
+        client.wait_for("client base placement", lambda: session._has_state(client, "BuildNewBaseState"))
+        client.ok({"cmd": "place_first_base", "lon": 0.7063353365604198, "lat": -0.5070346730015731, "name": "SoloBase"})
+        client.ok({"cmd": "open_server_browser"})
+
+        host.ok({"cmd": "open_new_game", "mode": "coop"})
+        host.wait_for("difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("host window", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47901", "player": "HostPlayer"})
+        host.wait_for("host lobby", lambda: session._has_state(host, "LobbyMenu"))
+
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47901", "player": "ClientPlayer"})
+        client.wait_for("client lobby over browser", lambda: session._has_state(client, "LobbyMenu"))
+
+        # host tears the session down while the client sits in the lobby
+        host.ok({"cmd": "lobby_disconnect"})
+        time.sleep(4)  # give the client's lobby think() time to misbehave
+        st = session.states(client)
+        assert sum(1 for s in st if "ServerList" in s) <= 1, f"BUG3: stacked server browsers: {st}"
+        if "CoopState" in geo.top_state(client):
+            client.ok({"cmd": "coop_dialog_back"})  # dismiss "connection lost"
+            time.sleep(1)
+        st = session.states(client)
+        assert "CoopState" not in geo.top_state(client), f"BUG3: stray dialog persists: {st}"
+        assert sum(1 for s in st if "ServerList" in s) <= 1, f"BUG3: stacked server browsers: {st}"
+        print("PASS bug3a: host-initiated drop leaves a clean stack")
+
+        # client-initiated disconnect: leave via the lobby button, then make
+        # sure exactly one browser (no stacking, no reconnect dialog)
+        host.wait_for("host window after drop", lambda: session._has_state(host, "HostMenu"))
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47902", "player": "HostPlayer"})
+        host.wait_for("host lobby again", lambda: session._has_state(host, "LobbyMenu"))
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47902", "player": "ClientPlayer"})
+        client.wait_for("client lobby again", lambda: session._has_state(client, "LobbyMenu"))
+        client.ok({"cmd": "lobby_disconnect"})
+        time.sleep(4)
+        st = session.states(client)
+        assert sum(1 for s in st if "ServerList" in s) <= 1, f"BUG3: stacked browsers after client disconnect: {st}"
+        if "CoopState" in geo.top_state(client):
+            client.ok({"cmd": "coop_dialog_back"})
+            time.sleep(1)
+        st = session.states(client)
+        assert "CoopState" not in geo.top_state(client), f"BUG3: stray dialog after client disconnect: {st}"
+        assert sum(1 for s in st if "ServerList" in s) <= 1, f"BUG3: stacked browsers after dismiss: {st}"
+        print("PASS bug3b: client-initiated disconnect leaves a clean stack")
+
+        # reset both instances for the campaign scenarios
+        host.shutdown(); client.shutdown()
+        host = GameClient("host", 48682, host_dir)
+        client = GameClient("client", 48683, make_user_dir("hard_client2"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client)
+        host.ok({"cmd": "save_game_ui", "type": "quick"})
+        host.wait_for(
+            "host quicksave",
+            lambda: os.path.exists(os.path.join(host_dir, "xcom1", "_quick_.asav")) or None,
+            timeout=60,
+        )
+        host.ok({"cmd": "save_game", "file": SAVE})
+        host.shutdown(); client.shutdown()
+
+        # ---------- Bug 4: wrong host name cannot host the save ----------
+        host = GameClient("host", 48684, host_dir)
+        host.spawn(); host.connect()
+        host.ok({"cmd": "load_save_menu", "file": SAVE})
+        host.wait_for("host window (resume)", lambda: session._has_state(host, "HostMenu"))
+        r = host.cmd({"cmd": "host_tcp", "server": "TestSrv", "port": "47903", "player": "WrongHost"})
+        assert not r.get("ok"), f"BUG4: a different name hosted the campaign save: {r}"
+        print("PASS bug4: campaign save refuses a different host name")
+
+        # correct name hosts fine
+        host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47903", "player": "HostPlayer"})
+        host.wait_for("resume lobby", lambda: session._has_state(host, "LobbyMenu"))
+
+        # ---------- Bug 5: waiting text merges names + port ----------
+        # detailsText is refreshed on the lobby's ~1s think cadence; the first
+        # frame still shows the ctor's generic "Waiting for players on port X".
+        # Poll for the merged form rather than reading that transient default.
+        details = host.wait_for(
+            "resume waiting text merged (names + port)",
+            lambda: (lambda d: d if ("ClientPlayer" in d and "47903" in d) else None)(
+                host.cmd({"cmd": "lobby_state"}).get("detailsText", "")),
+            timeout=15,
+        )
+        print(f"PASS bug5: waiting text merged: {details!r}")
+
+        # ---------- Bug 6: the host's own name is refused ----------
+        joiner = GameClient("client", 48685, make_user_dir("hard_joiner"))
+        joiner.spawn(); joiner.connect()
+        joiner.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47903", "player": "HostPlayer"})
+        joiner.wait_for(
+            "duplicate name refused",
+            lambda: ("CoopState" in geo.top_state(joiner)) or None,
+            timeout=60,
+        )
+        r = joiner.cmd({"cmd": "get_coop"})
+        assert not r.get("coopStatic"), f"BUG6: duplicate name entered the session: {r}"
+        ls = host.ok({"cmd": "lobby_state"})
+        assert ls.get("lobbyMode") == 2 and not ls.get("startEligible"), \
+            f"BUG6: host lobby thinks the duplicate joined: {ls}"
+        print("PASS bug6: duplicate player name refused")
+        joiner.shutdown(); joiner = None
+
+        # ---------- Bug 1: UDP-public host attempt never strands a blank window ----------
+        # (offline: the rendezvous registration cannot succeed; whatever happens,
+        # any HostMenu still on screen must keep its controls usable)
+        host.ok({"cmd": "lobby_disconnect"})
+        host.wait_for("host window again", lambda: session._has_state(host, "HostMenu"))
+        for cycle in range(3):
+            host.ok({"cmd": "host_menu_host", "visibility": 2})  # UDP public
+            time.sleep(3)
+            hs = host.ok({"cmd": "host_menu_state"})
+            if hs["open"]:
+                assert hs["controlsVisible"], \
+                    f"BUG1: blank host window (cycle {cycle}): {session.states(host)}"
+            # tear down whatever came up (dialogs, lobby, in any order) until
+            # a host window surfaces again
+            for _ in range(8):
+                t = geo.top_state(host)
+                if "HostMenu" in t:
+                    break
+                if "CoopState" in t:
+                    host.cmd({"cmd": "coop_dialog_back"})
+                elif "LobbyMenu" in t:
+                    host.cmd({"cmd": "lobby_disconnect"})
+                time.sleep(1)
+            host.wait_for(
+                "host window for next cycle",
+                lambda: ("HostMenu" in geo.top_state(host)) or None,
+                timeout=30,
+            )
+        hs = host.ok({"cmd": "host_menu_state"})
+        assert hs["open"] and hs["controlsVisible"], f"BUG1: final host window unusable: {session.states(host)}"
+        print("PASS bug1: UDP host/disconnect cycles never strand a blank host window")
+
+        # ---------- C1 (PRD-04): a solo save written after a coop session loads ----------
+        # A coop session leaves connectionTCP::saveID nonzero in-process. Before
+        # PRD-04, a later solo save carried that nonzero saveID with no coop
+        # marker, so loading it threw "made on an earlier version". Verify the
+        # solo save loads and no foreign host_* blob survives.
+        host.shutdown(); client.shutdown()
+        host = GameClient("host", 48690, make_user_dir("c1_host"))
+        client = GameClient("client", 48691, make_user_dir("c1_client"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client, port="47910")
+        id_a = host.ok({"cmd": "save_markers"})["saveID"]
+        assert id_a != 0, "C1 setup: campaign saveID should be nonzero"
+        key_a = f"host_{id_a}_ClientPlayer.data"
+        assert host.ok({"cmd": "has_coop_file", "key": key_a}).get("present"), \
+            "C1 setup: client world blob should be present after the campaign"
+
+        # disconnect both to the main menu (the ex-host stays the same process)
+        host.ok({"cmd": "disconnect_to_menu"})
+        client.ok({"cmd": "disconnect_to_menu"})
+        time.sleep(3)
+
+        # ex-host builds a SOLO game in the SAME process
+        host.ok({"cmd": "open_new_game", "mode": "solo"})
+        host.wait_for("solo difficulty", lambda: session._has_state(host, "NewGameState"))
+        host.ok({"cmd": "newgame_ok"})
+        host.wait_for("solo base placement", lambda: session._has_state(host, "BuildNewBaseState"))
+        r = host.cmd({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "SoloBase"})
+        assert r.get("ok"), f"C1 setup: solo base placement failed: {r}"
+        host.ok({"cmd": "save_game", "file": "solo_after_coop.sav"})
+
+        r = host.cmd({"cmd": "load_save", "file": "solo_after_coop.sav"})
+        assert r.get("ok"), f"C1: solo save written after a coop session is unloadable: {r}"
+        assert not host.ok({"cmd": "has_coop_file", "key": key_a}).get("present"), \
+            "C1: a stale host_* blob survived the solo load"
+        print("PASS C1: solo save after coop loads cleanly, no stale blob")
+
+        # ---------- C2 (PRD-04): a second campaign mints a fresh saveID ----------
+        # Before PRD-04 nothing regenerated saveID or cleared the blob maps, so a
+        # second campaign in the same process reused the first's ID and served its
+        # stale client world.
+        host.shutdown(); client.shutdown()
+        host = GameClient("host", 48692, make_user_dir("c2_host"))
+        client = GameClient("client", 48693, make_user_dir("c2_client"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client, port="47911")
+        id_1 = host.ok({"cmd": "save_markers"})["saveID"]
+        assert id_1 != 0, "C2 setup: first campaign saveID should be nonzero"
+        key_1 = f"host_{id_1}_ClientPlayer.data"
+        assert host.ok({"cmd": "has_coop_file", "key": key_1}).get("present"), \
+            "C2 setup: first campaign blob should be present"
+
+        # tear the session down to the main menu in-process (resetSession fires):
+        # a pristine identity means the first campaign's blob is gone.
+        host.ok({"cmd": "disconnect_to_menu"})
+        client.ok({"cmd": "disconnect_to_menu"})
+        time.sleep(3)
+        assert not host.ok({"cmd": "has_coop_file", "key": key_1}).get("present"), \
+            "C2: resetSession did not clear the first campaign's blob maps"
+
+        # second campaign on the SAME instances
+        session.new_campaign(host, client, port="47912")
+        id_2 = host.ok({"cmd": "save_markers"})["saveID"]
+        assert id_2 != 0 and id_2 != id_1, \
+            f"C2: second campaign reused the first saveID (id1={id_1}, id2={id_2})"
+        assert not host.ok({"cmd": "has_coop_file", "key": key_1}).get("present"), \
+            "C2: the first campaign's stale blob is still being served"
+        print(f"PASS C2: second campaign minted a fresh saveID ({id_1} -> {id_2})")
+
+        # ---------- C7 (PRD-08): host mid-session local load is refused ----------
+        # A live coop session forbids local loads for everyone, host included -
+        # loading mid-session forks the served world silently (the client keeps
+        # its live/now-future world and its next progress push clobbers the
+        # rolled-back one). After the session ends, loads are allowed again.
+        host.shutdown(); client.shutdown()
+        c7_host_dir = make_user_dir("c7_host")
+        host = GameClient("host", 48694, c7_host_dir)
+        client = GameClient("client", 48695, make_user_dir("c7_client"))
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        session.new_campaign(host, client, port="47913")
+        # host writes a real save it will then try to reload mid-session
+        host.ok({"cmd": "save_game", "file": SAVE})
+        saveid_live = host.ok({"cmd": "get_coop"}).get("saveID")
+
+        host.cmd({"cmd": "load_save_menu", "file": SAVE})
+        time.sleep(3)
+        gc = host.ok({"cmd": "get_coop"})
+        assert gc.get("coopSession"), \
+            f"C7: host mid-session load tore down the live session: {gc}"
+        assert gc.get("saveID") == saveid_live, \
+            f"C7: host mid-session load switched worlds (saveID {saveid_live} -> {gc.get('saveID')})"
+        assert "LoadGameState" not in geo.top_state(host), \
+            f"C7: LoadGameState lingering after refusal: {geo.top_state(host)}"
+        print("PASS C7: host mid-session local load refused")
+
+        # end the session -> solo -> a local load is allowed again and routes to
+        # the host's resume window (coop save -> HostMenu / resume lobby)
+        host.ok({"cmd": "disconnect_to_menu"})
+        client.ok({"cmd": "disconnect_to_menu"})
+        time.sleep(3)
+        host.ok({"cmd": "load_save_menu", "file": SAVE})
+        host.wait_for(
+            "post-session load routed",
+            lambda: (session._has_state(host, "HostMenu")
+                     or session._has_state(host, "GeoscapeState")
+                     or session._has_state(host, "LobbyMenu")) or None,
+            timeout=30,
+        )
+        print("PASS C7b: local load allowed after the session ends")
+
+        print("ALL SESSION HARDENING TESTS PASSED")
+    finally:
+        host.shutdown()
+        client.shutdown()
+        if joiner:
+            joiner.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_transfer_fresh.py
+++ b/tools/coop_test/test_transfer_fresh.py
@@ -10,8 +10,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import GameClient, make_user_dir, LAND_LON, LAND_LAT
-
-HOST_LON, HOST_LAT = 0.35, 0.85  # different land spot for the host base
+import session
 
 
 def main():
@@ -21,48 +20,7 @@ def main():
         host.spawn(); client.spawn()
         host.connect(); client.connect()
 
-        for gc in (host, client):
-            gc.ok({"cmd": "set_option", "name": "HostSaveProgress", "value": True})
-
-        # --- host: brand-new campaign ---
-        host.ok({"cmd": "open_new_game"})
-        host.wait_for("difficulty", lambda: any("NewGameState" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-        host.ok({"cmd": "newgame_ok"})
-        host.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-        r = host.cmd({"cmd": "place_first_base", "lon": HOST_LON, "lat": HOST_LAT, "name": "HostBase"})
-        if not r.get("ok"):
-            # fall back to the known-good land spot
-            host.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "HostBase"})
-        host.wait_for("host on geoscape", lambda: (lambda st: "GeoscapeState" in st[0] and len(st) == 1 or None)([s for s in host.cmd({"cmd": "get_state"})["states"]]))
-
-        # --- host up, client join, same lobby dance as legacy test ---
-        r = host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": "47900", "player": "HostPlayer"})
-        assert r["campaign"], "fresh campaign should count as campaign"
-
-        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47900", "player": "ClientPlayer"})
-        host.wait_for("client joined", lambda: host.cmd({"cmd": "get_coop"}).get("coopStatic") or None)
-
-        host.wait_for("host profile", lambda: any("Profile" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-        host.ok({"cmd": "profile_ok"})
-        client.wait_for("client profile", lambda: any("Profile" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-        client.ok({"cmd": "profile_ok"})
-
-        client.wait_for("difficulty", lambda: any("NewGameState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-        client.ok({"cmd": "newgame_ok"})
-        client.wait_for("base placement", lambda: any("BuildNewBaseState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "ClientBase"})
-
-        client.wait_for("client lobby", lambda: any("LobbyMenu" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
-        client.ok({"cmd": "lobby_ready"})
-        host.ok({"cmd": "lobby_ready"})
-        client.wait_for("locked", lambda: client.cmd({"cmd": "get_coop"}).get("sessionLocked") or None, timeout=60)
-        host.ok({"cmd": "lobby_ready"})
-        client.ok({"cmd": "lobby_ready"})
-        client.wait_for(
-            "lobby closed + save synced",
-            lambda: (lambda c: (c.get("lobbyClosed") and c.get("hasSave")) or None)(client.cmd({"cmd": "get_coop"})),
-            timeout=120,
-        )
+        session.new_campaign(host, client)
         print("fresh coop session established")
 
         # --- pick host's first soldier, transfer, verify ---


### PR DESCRIPTION
## Summary

Resolves https://github.com/xcomcoopdev/OpenXcom-Coop-Mod/issues/27.

This branch makes the host's save the single authority for a co-op campaign, redesigns the campaign/lobby flow around it, and hardens the result. The client writes zero save data to disk; the host .sav embeds each client's world blob.

Full automated harness suite (15 test_*.py) green.

## Host-authoritative saves

- The host .sav is the only save artifact. World blobs live in RAM and are streamed to clients on join/resume; the client never writes .sav / .asav / .data to disk (enforced by a client-side save gate and guarded by test_client_zero_disk).
- saveID and the in-memory blob maps are owned by the CoopSession lifecycle and reset only through the two teardown paths, so a later solo save or a second campaign cannot inherit a stale identity or stale world.

## Campaign and lobby flow redesign

- Solo vs Co-op split at New Game; co-op campaigns run through a host-driven lobby (START CAMPAIGN, base building, RESUME) instead of the legacy ready dance.
- Resume lobby: menu load interposition, roster gate (only registered players may join, no duplicate names), and a host RESUME that serves every client its world.
- Mid-session freeze plus direct rejoin: a dropped player freezes the session; a fresh client process with the registered name reconnects and is served its world without a lobby round trip.

## Hardening

- Structured in-RAM blob store with no data loss on key handling; deferred-save integrity plus blob validation and rollback; host quickload policy and mission-end world restore; a lobby start gate that refuses a lone or departed roster.
- Network robustness: a busy host now replies and the client retries with a bounded backoff instead of hanging forever; the battle stream only goes to a client that was actually served a resume world; a spoofed server_full can no longer stop the host's listen thread.
- CoopSession cleanup: deleted a write-only lifecycle enum and funneled every multi-field or cross-file session write through named, logged transition methods, with no change to any predicate's truth value.
- Test infrastructure dedup: a findState/topState template in TestServer and shared Python helpers replace copy-pasted scans.

## Lobby and wait-dialog fixes

1. Client leaving a lobby no longer resurfaces a stale "Connecting..." window that was buried under the lobby and never popped.
2. When all bases are placed the host dialog reads "All bases placed." with a BEGIN button (was "All players connected" / RESUME).
3. The host's wait-for-bases dialog now shares the client's message and compact styling instead of a large poorly-scaled window.
4. A rejoining client holds with "Waiting for host to resume the game." instead of the fresh-placement message.
5. The "Waiting for [player] to reconnect" freeze dialog is now a compact strip (about 30 percent of the old height) with smaller text.

## Testing

- In-game TestServer harness (OXC_TEST_PORT) spawns real game instances; every fix ships with or is covered by a test_*.py.
- New test_lobby_dialogs.py covers the five dialog bugs via new coop_dialog_info / coop_push_connecting harness commands.
- Build is incremental serial msbuild (Release x64); boot_check plus the full suite pass.

Reviewer note: the migration and flow changes have been exercised through the automated harness; the battle-resume variants still warrant a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
