### PR TITLE
Hide foreign base equipment, gift rename, transfer-with-gear option

### DIFF
--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -49,7 +49,7 @@
 
 #include "../CoopMod/CoopMenu.h"
 #include "../CoopMod/connectionTCP.h" // coop
-#include "../CoopMod/TransferSoldierMenu.h" // coop
+#include "../CoopMod/GiftSoldierMenu.h" // coop
 #include "../Savegame/Vehicle.h"
 
 namespace OpenXcom
@@ -671,7 +671,7 @@ void CraftSoldiersState::lstSoldiersMousePress(Action *action)
 }
 
 /**
- * Coop: opens the transfer-ownership dialog for the hovered soldier.
+ * Coop: opens the gift dialog for the hovered soldier.
  * @param action Pointer to an action.
  */
 void CraftSoldiersState::lstSoldiersGiveUnitPress(Action *)
@@ -686,7 +686,7 @@ void CraftSoldiersState::lstSoldiersGiveUnitPress(Action *)
 		return;
 	}
 	Soldier *soldier = _base->getSoldiers()->at(row);
-	_game->pushState(new TransferSoldierMenu(soldier, TransferSoldierMenu::resolveOwnerId(soldier)));
+	_game->pushState(new GiftSoldierMenu(soldier, GiftSoldierMenu::resolveOwnerId(soldier)));
 }
 
 /**

--- a/src/Basescape/SoldierInfoState.cpp
+++ b/src/Basescape/SoldierInfoState.cpp
@@ -47,7 +47,7 @@
 #include "../Mod/RuleSoldier.h"
 #include "../Savegame/SoldierDeath.h"
 #include "../CoopMod/connectionTCP.h" // coop
-#include "../CoopMod/TransferSoldierMenu.h" // coop
+#include "../CoopMod/GiftSoldierMenu.h" // coop
 
 namespace OpenXcom
 {
@@ -693,7 +693,7 @@ void SoldierInfoState::btnOkClick(Action *)
 }
 
 /**
- * Coop: opens the transfer-ownership dialog for this soldier.
+ * Coop: opens the gift dialog for this soldier.
  * @param action Pointer to an action.
  */
 void SoldierInfoState::btnGiveUnitPress(Action *)
@@ -707,7 +707,7 @@ void SoldierInfoState::btnGiveUnitPress(Action *)
 	{
 		return;
 	}
-	_game->pushState(new TransferSoldierMenu(_soldier, TransferSoldierMenu::resolveOwnerId(_soldier)));
+	_game->pushState(new GiftSoldierMenu(_soldier, GiftSoldierMenu::resolveOwnerId(_soldier)));
 }
 
 /**

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -33,6 +33,9 @@
 #include "../Interface/Text.h"
 #include "../Interface/TextList.h"
 #include "../Savegame/Base.h"
+#include "../Savegame/EquipmentLayoutItem.h"
+#include "../Savegame/ItemContainer.h"
+#include "../Mod/RuleItem.h"
 #include "../Savegame/BattleUnit.h"
 #include "../Savegame/Soldier.h"
 #include "../Savegame/SavedGame.h"
@@ -48,7 +51,7 @@
 
 #include "../Savegame/Vehicle.h"
 #include "../CoopMod/connectionTCP.h" // coop
-#include "../CoopMod/TransferSoldierMenu.h" // coop
+#include "../CoopMod/GiftSoldierMenu.h" // coop
 
 namespace OpenXcom
 {
@@ -845,9 +848,56 @@ void SoldiersState::btnInventoryClick(Action *)
 		{
 			_game->getSavedGame()->setDisableSoldierEquipment(true);
 		}
+
+		// Issue #33 (own-base variant): coop "guest" soldiers stationed at this
+		// base are stripped from the editable roster (see the SoldiersState ctor),
+		// so they are not deployed for this inventory - but their equipment-layout
+		// items still sit in this base's storage and would otherwise show up as
+		// free/available on the ground pane. Pull those reserved items out of
+		// storage while runInventory builds the ground, then put them straight
+		// back. Base-mode runInventory never mutates storage, so the real save is
+		// left untouched.
+		std::vector<const RuleItem*> hiddenReserved;
+		if (_game->getCoopMod()->getCoopStatic() && _game->getCoopMod()->getCoopCampaign() && _base->_coopBase == false)
+		{
+			for (auto* guest : _base->base_oldsoldiers)
+			{
+				if (guest->getCoopBase() == -1)
+				{
+					continue; // an editable own soldier - it is deployed normally
+				}
+				for (auto* layoutItem : *guest->getEquipmentLayout())
+				{
+					const RuleItem* itemRule = layoutItem->getItemType();
+					if (itemRule)
+					{
+						hiddenReserved.push_back(itemRule);
+					}
+					for (int ammoSlot = 0; ammoSlot < RuleItem::AmmoSlotMax; ++ammoSlot)
+					{
+						const RuleItem* ammoRule = layoutItem->getAmmoItemForSlot(ammoSlot);
+						if (ammoRule)
+						{
+							hiddenReserved.push_back(ammoRule);
+						}
+					}
+				}
+			}
+			for (const RuleItem* itemRule : hiddenReserved)
+			{
+				_base->getStorageItems()->removeItem(itemRule, 1);
+			}
+		}
+
 		BattlescapeGenerator bgen = BattlescapeGenerator(_game);
 		bgen.setBase(_base);
 		bgen.runInventory(0);
+
+		// restore the reserved items pulled out above (see issue #33 note)
+		for (const RuleItem* itemRule : hiddenReserved)
+		{
+			_base->getStorageItems()->addItem(itemRule, 1);
+		}
 
 		// pre-select the soldier under the mouse cursor (if possible)
 		if (_availableOptions.empty() || _cbxScreenActions->getSelected() == 0)
@@ -958,7 +1008,7 @@ void SoldiersState::lstSoldiersMousePress(Action *action)
 
 
 /**
- * Coop: opens the transfer-ownership dialog for the hovered soldier.
+ * Coop: opens the gift dialog for the hovered soldier.
  * @param action Pointer to an action.
  */
 void SoldiersState::lstSoldiersGiveUnitPress(Action *)
@@ -973,7 +1023,7 @@ void SoldiersState::lstSoldiersGiveUnitPress(Action *)
 		return;
 	}
 	Soldier *soldier = _filteredListOfSoldiers[row];
-	_game->pushState(new TransferSoldierMenu(soldier, TransferSoldierMenu::resolveOwnerId(soldier)));
+	_game->pushState(new GiftSoldierMenu(soldier, GiftSoldierMenu::resolveOwnerId(soldier)));
 }
 
 }

--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -38,6 +38,7 @@
 #include "../Savegame/Soldier.h"
 #include "../Savegame/Craft.h"
 #include "../Savegame/ItemContainer.h"
+#include "../Savegame/EquipmentLayoutItem.h"
 #include "../Mod/RuleItem.h"
 #include "../Engine/Timer.h"
 #include "../Menu/ErrorMessageState.h"
@@ -552,6 +553,20 @@ void TransferItemsState::btnOkClick(Action *)
 /**
  * Completes the transfer between bases.
  */
+bool TransferItemsState::transferSoldierNow(Soldier* soldier)
+{
+	for (auto& row : _items)
+	{
+		if (row.type == TRANSFER_SOLDIER && row.rule == (const void*)soldier)
+		{
+			row.amount = 1;
+			completeTransfer();
+			return true;
+		}
+	}
+	return false;
+}
+
 void TransferItemsState::completeTransfer()
 {
 	int time = (int)floor(6 + _distance / 10.0);
@@ -582,6 +597,45 @@ void TransferItemsState::completeTransfer()
 							t->setSoldier(soldier);
 
 							_baseTo->getTransfers()->push_back(t);
+
+							// Coop: equipment behaviour on transfer to a peer base follows the
+							// "Alternate craft equipment management" option. OFF (default): a
+							// soldier's gear does not travel between bases, so strip its layout
+							// and it arrives empty. ON: move each reserved item (weapon + loaded
+							// ammo) out of the sending base's storage into the transfer, so it
+							// arrives at the receiving base with the soldier.
+							if (_baseTo->_coopBase)
+							{
+								if (Options::oxceAlternateCraftEquipmentManagement)
+								{
+									for (auto* layoutItem : *soldier->getEquipmentLayout())
+									{
+										const RuleItem* itemRule = layoutItem->getItemType();
+										if (itemRule && _baseFrom->getStorageItems()->getItem(itemRule) > 0)
+										{
+											_baseFrom->getStorageItems()->removeItem(itemRule, 1);
+											Transfer* et = new Transfer(0);  // 0h = lands immediately at the peer base
+											et->setItems(itemRule, 1);
+											_baseTo->getTransfers()->push_back(et);
+										}
+										for (int ammoSlot = 0; ammoSlot < RuleItem::AmmoSlotMax; ++ammoSlot)
+										{
+											const RuleItem* ammoRule = layoutItem->getAmmoItemForSlot(ammoSlot);
+											if (ammoRule && _baseFrom->getStorageItems()->getItem(ammoRule) > 0)
+											{
+												_baseFrom->getStorageItems()->removeItem(ammoRule, 1);
+												Transfer* at = new Transfer(0);  // 0h = lands immediately at the peer base
+												at->setItems(ammoRule, 1);
+												_baseTo->getTransfers()->push_back(at);
+											}
+										}
+									}
+								}
+								else
+								{
+									soldier->clearEquipmentLayout();
+								}
+							}
 
 							// coop
 							if (_baseTo->_coopIcon == false)

--- a/src/Basescape/TransferItemsState.h
+++ b/src/Basescape/TransferItemsState.h
@@ -35,6 +35,7 @@ class Timer;
 class Base;
 class DebriefingState;
 class RuleItem;
+class Soldier;
 
 /**
  * Transfer screen that lets the player pick
@@ -92,6 +93,10 @@ public:
 	void btnTransferAllClick(Action *action);
 	/// Completes the transfer between bases.
 	void completeTransfer();
+	/// Programmatic single-soldier transfer (test-harness hook): sets that
+	/// soldier's row amount to 1 and completes the transfer. Returns false if
+	/// the soldier is not a transferable row.
+	bool transferSoldierNow(Soldier* soldier);
 	/// Handler for clicking the Cancel button.
 	void btnCancelClick(Action *action);
 	/// Handler for pressing an Increase arrow in the list.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,8 +158,8 @@ set(coopmod_src
   CoopMod/connectionUDP/rendezvous_client.cpp
   CoopMod/connectionUDP/rendezvous_config.cpp
   CoopMod/connectionUDP/rendezvous_server.cpp
-  CoopMod/TransferNoticeState.cpp
-  CoopMod/TransferSoldierMenu.cpp
+  CoopMod/GiftNoticeState.cpp
+  CoopMod/GiftSoldierMenu.cpp
   CoopMod/TestServer.cpp
 )
 

--- a/src/CoopMod/CoopState.cpp
+++ b/src/CoopMod/CoopState.cpp
@@ -40,6 +40,9 @@
 #include "../Basescape/BasescapeState.h"
 
 #include "../Savegame/Soldier.h"
+#include "../Savegame/EquipmentLayoutItem.h"
+#include "../Savegame/ItemContainer.h"
+#include "../Mod/RuleItem.h"
 #include "../Savegame/Vehicle.h"
 
 #include "../Menu/SaveGameState.h"
@@ -1287,6 +1290,35 @@ void CoopState::loadWorld()
 			{
 
 				newbase->isCoopBase(true);
+
+				// Issue #33: the peer's own soldiers are about to be removed from
+				// this visited-base view (only the visitor's guest soldiers are
+				// shown), but a soldier's equipment layout does NOT decrement base
+				// storage - the physical items stay in storage. If we drop the
+				// soldiers but keep their reserved items in storage, those items
+				// appear as free/available on the inventory ground pane. Remove
+				// each departing soldier's layout items (weapon + loaded ammo)
+				// from the visited base's storage so the visitor only sees the
+				// peer's genuinely free equipment.
+				for (auto* peerSoldier : *newbase->getSoldiers())
+				{
+					for (auto* layoutItem : *peerSoldier->getEquipmentLayout())
+					{
+						const RuleItem* itemRule = layoutItem->getItemType();
+						if (itemRule)
+						{
+							newbase->getStorageItems()->removeItem(itemRule, 1);
+						}
+						for (int ammoSlot = 0; ammoSlot < RuleItem::AmmoSlotMax; ++ammoSlot)
+						{
+							const RuleItem* ammoRule = layoutItem->getAmmoItemForSlot(ammoSlot);
+							if (ammoRule)
+							{
+								newbase->getStorageItems()->removeItem(ammoRule, 1);
+							}
+						}
+					}
+				}
 
 				// clear all vehicles and soldiers from the base
 				newbase->getSoldiers()->clear();

--- a/src/CoopMod/GiftNoticeState.cpp
+++ b/src/CoopMod/GiftNoticeState.cpp
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "TransferNoticeState.h"
+#include "GiftNoticeState.h"
 
 #include "../Engine/Action.h"
 #include "../Engine/Game.h"
@@ -34,7 +34,7 @@
 namespace OpenXcom
 {
 
-TransferNoticeState::TransferNoticeState(const std::string &message)
+GiftNoticeState::GiftNoticeState(const std::string &message)
 {
 	_screen = false;
 
@@ -66,7 +66,7 @@ TransferNoticeState::TransferNoticeState(const std::string &message)
 		State* context = nullptr;
 		for (auto it = _game->getStates().rbegin(); it != _game->getStates().rend(); ++it)
 		{
-			if (dynamic_cast<TransferNoticeState*>(*it) == nullptr)
+			if (dynamic_cast<GiftNoticeState*>(*it) == nullptr)
 			{
 				context = *it;
 				break;
@@ -101,12 +101,12 @@ TransferNoticeState::TransferNoticeState(const std::string &message)
 	_txtMessage->setText(message);
 
 	_btnOk->setText(tr("STR_OK"));
-	_btnOk->onMouseClick((ActionHandler)&TransferNoticeState::btnOkClick);
-	_btnOk->onKeyboardPress((ActionHandler)&TransferNoticeState::btnOkClick, Options::keyOk);
-	_btnOk->onKeyboardPress((ActionHandler)&TransferNoticeState::btnOkClick, Options::keyCancel);
+	_btnOk->onMouseClick((ActionHandler)&GiftNoticeState::btnOkClick);
+	_btnOk->onKeyboardPress((ActionHandler)&GiftNoticeState::btnOkClick, Options::keyOk);
+	_btnOk->onKeyboardPress((ActionHandler)&GiftNoticeState::btnOkClick, Options::keyCancel);
 }
 
-void TransferNoticeState::btnOkClick(Action *)
+void GiftNoticeState::btnOkClick(Action *)
 {
 	_game->popState();
 }

--- a/src/CoopMod/GiftNoticeState.h
+++ b/src/CoopMod/GiftNoticeState.h
@@ -29,12 +29,12 @@ class Text;
 class TextButton;
 
 /**
- * Small co-op notification popup ("X transferred ownership of Y to you...").
+ * Small co-op notification popup ("X gifted Y to you...").
  * Adopts the palette of the state it is pushed over, so it can appear on any
  * screen (geoscape, basescape, peer-base view) without a palette flash. As a
  * side effect, closing it re-inits the state below, refreshing soldier lists.
  */
-class TransferNoticeState : public State
+class GiftNoticeState : public State
 {
 private:
 	Window *_window;
@@ -43,7 +43,7 @@ private:
 	std::string _category;
 
 public:
-	TransferNoticeState(const std::string &message);
+	GiftNoticeState(const std::string &message);
 	void btnOkClick(Action *action);
 	/// Interface category the widgets were themed with (test introspection).
 	const std::string &getCategory() const { return _category; }

--- a/src/CoopMod/GiftSoldierMenu.cpp
+++ b/src/CoopMod/GiftSoldierMenu.cpp
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "TransferSoldierMenu.h"
+#include "GiftSoldierMenu.h"
 
 #include "../Engine/Action.h"
 #include "../Engine/Game.h"
@@ -33,7 +33,7 @@
 namespace OpenXcom
 {
 
-int TransferSoldierMenu::resolveOwnerId(Soldier *soldier)
+int GiftSoldierMenu::resolveOwnerId(Soldier *soldier)
 {
 	if (soldier->getOwnerPlayerId() != 999)
 	{
@@ -47,7 +47,7 @@ int TransferSoldierMenu::resolveOwnerId(Soldier *soldier)
 	return connectionTCP::getHost() ? 0 : 1;
 }
 
-TransferSoldierMenu::TransferSoldierMenu(Soldier *soldier, int currentOwnerId) : _soldier(soldier)
+GiftSoldierMenu::GiftSoldierMenu(Soldier *soldier, int currentOwnerId) : _soldier(soldier)
 {
 	_screen = false;
 
@@ -133,7 +133,7 @@ TransferSoldierMenu::TransferSoldierMenu(Soldier *soldier, int currentOwnerId) :
 
 	_txtTitle->setAlign(ALIGN_CENTER);
 	_txtTitle->setWordWrap(true);
-	_txtTitle->setText("Transfer " + _soldier->getName() + " to another player?");
+	_txtTitle->setText("Gift " + _soldier->getName() + " to another player?");
 
 	for (size_t i = 0; i < _btnTargets.size(); ++i)
 	{
@@ -143,28 +143,28 @@ TransferSoldierMenu::TransferSoldierMenu(Soldier *soldier, int currentOwnerId) :
 			name = targets[i].first == 0 ? "HOST" : "CLIENT";
 		}
 		_btnTargets[i]->setText(name);
-		_btnTargets[i]->onMouseClick((ActionHandler)&TransferSoldierMenu::btnTransferClick);
+		_btnTargets[i]->onMouseClick((ActionHandler)&GiftSoldierMenu::btnGiftClick);
 	}
 
 	_btnCancel->setText(tr("STR_CANCEL"));
-	_btnCancel->onMouseClick((ActionHandler)&TransferSoldierMenu::btnCancelClick);
-	_btnCancel->onKeyboardPress((ActionHandler)&TransferSoldierMenu::btnCancelClick, Options::keyCancel);
+	_btnCancel->onMouseClick((ActionHandler)&GiftSoldierMenu::btnCancelClick);
+	_btnCancel->onKeyboardPress((ActionHandler)&GiftSoldierMenu::btnCancelClick, Options::keyCancel);
 }
 
-void TransferSoldierMenu::btnTransferClick(Action *action)
+void GiftSoldierMenu::btnGiftClick(Action *action)
 {
 	for (size_t i = 0; i < _btnTargets.size(); ++i)
 	{
 		if (action->getSender() == _btnTargets[i])
 		{
-			_game->getCoopMod()->transferSoldierOwnership(_soldier, _targetIds[i], true);
+			_game->getCoopMod()->giftSoldier(_soldier, _targetIds[i], true);
 			break;
 		}
 	}
 	_game->popState();
 }
 
-void TransferSoldierMenu::btnCancelClick(Action *)
+void GiftSoldierMenu::btnCancelClick(Action *)
 {
 	_game->popState();
 }

--- a/src/CoopMod/GiftSoldierMenu.h
+++ b/src/CoopMod/GiftSoldierMenu.h
@@ -37,7 +37,7 @@ class Soldier;
  * "Give Unit to Teammate" keybind (Options::giveUnit) from the base soldier
  * lists, the soldier stat screen, or the battlescape.
  */
-class TransferSoldierMenu : public State
+class GiftSoldierMenu : public State
 {
 private:
 	Window *_window;
@@ -50,11 +50,11 @@ private:
 
 public:
 	/// Creates the dialog. currentOwnerId: 0 = host, 1 = client.
-	TransferSoldierMenu(Soldier *soldier, int currentOwnerId);
+	GiftSoldierMenu(Soldier *soldier, int currentOwnerId);
 	/// Resolves who currently owns a soldier (0 = host, 1 = client) from its
 	/// persistent owner id, falling back to the co-op control flag.
 	static int resolveOwnerId(Soldier *soldier);
-	void btnTransferClick(Action *action);
+	void btnGiftClick(Action *action);
 	void btnCancelClick(Action *action);
 };
 

--- a/src/CoopMod/TestServer.cpp
+++ b/src/CoopMod/TestServer.cpp
@@ -64,6 +64,10 @@
 #include "../Savegame/SavedBattleGame.h"
 #include "../Savegame/SavedGame.h"
 #include "../Savegame/Soldier.h"
+#include "../Savegame/Transfer.h"
+#include "../Savegame/EquipmentLayoutItem.h"
+#include "../Savegame/ItemContainer.h"
+#include "../Savegame/Tile.h"
 #include "../Savegame/Ufo.h"
 #include "../Savegame/CraftWeapon.h"
 #include "../Savegame/Target.h"
@@ -94,9 +98,10 @@
 #include "../Engine/Screen.h"
 #include "../Basescape/BasescapeState.h"
 #include "../Basescape/SoldiersState.h"
+#include "../Basescape/TransferItemsState.h"
 #include "CoopState.h"
-#include "TransferNoticeState.h"
-#include "TransferSoldierMenu.h"
+#include "GiftNoticeState.h"
+#include "GiftSoldierMenu.h"
 #include "../Interface/DisableableComboBox.h"
 
 namespace OpenXcom
@@ -991,7 +996,7 @@ std::string TestServer::execute(const std::string& line)
 			std::string file = req.get("file", "").asString();
 			SavedGame* s = new SavedGame();
 			s->load(file, _game->getMod(), _game->getLanguage());
-			coop->resetTransferSessionState();
+			coop->resetGiftSessionState();
 			_game->setSavedGame(s);
 			_game->setState(new GeoscapeState);
 			resp["ok"] = true;
@@ -1350,6 +1355,322 @@ std::string TestServer::execute(const std::string& line)
 				resp["error"] = "no SoldiersState in state stack";
 			}
 		}
+		else if (cmd == "base_report")
+		{
+			// Read-only snapshot of a base's equipment pool + its soldiers'
+			// reserved (equipment-layout) items. Proves issue #33: a visited
+			// coop base must not expose items reserved by the peer's soldiers'
+			// loadouts. Match: coop=true -> first visited coop base; else base
+			// name if given; else the local own base.
+			std::string reportBase = req.get("base", "").asString();
+			bool wantCoop = req.get("coop", false).asBool();
+			Base* target = nullptr;
+			if (_game->getSavedGame())
+			{
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					bool match;
+					if (wantCoop)
+						match = base->_coopBase;
+					else if (!reportBase.empty())
+						match = (base->getName() == reportBase);
+					else
+						match = (base->_coopBase == false && base->_coopIcon == false);
+					if (match) { target = base; break; }
+				}
+			}
+			if (!target)
+			{
+				resp["error"] = "base not found";
+			}
+			else
+			{
+				resp["name"] = target->getName();
+				resp["coopBaseFlag"] = target->_coopBase;
+				resp["coopBaseId"] = target->_coop_base_id;
+
+				Json::Value storage(Json::objectValue);
+				for (const auto& pair : *target->getStorageItems()->getContents())
+					storage[pair.first->getType()] = pair.second;
+				resp["storage"] = storage;
+
+				Json::Value reserved(Json::objectValue);
+				Json::Value soldiers(Json::arrayValue);
+				for (auto* s : *target->getSoldiers())
+				{
+					Json::Value js;
+					js["name"] = s->getName();
+					js["owner"] = s->getOwnerPlayerId();
+					js["coopBase"] = s->getCoopBase();
+					Json::Value layout(Json::arrayValue);
+					for (auto* eli : *s->getEquipmentLayout())
+					{
+						const RuleItem* it = eli->getItemType();
+						if (it)
+						{
+							layout.append(it->getType());
+							reserved[it->getType()] = reserved.get(it->getType(), 0).asInt() + 1;
+						}
+						for (int a = 0; a < RuleItem::AmmoSlotMax; ++a)
+						{
+							const RuleItem* am = eli->getAmmoItemForSlot(a);
+							if (am)
+								reserved[am->getType()] = reserved.get(am->getType(), 0).asInt() + 1;
+						}
+					}
+					js["layout"] = layout;
+					soldiers.append(js);
+				}
+				resp["soldiers"] = soldiers;
+				resp["reserved"] = reserved;
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "soldiers_inventory")
+		{
+			// Replicate the right-click "equip soldier at base" action: opens the
+			// base inventory (runInventory) for the top SoldiersState's base. The
+			// InventoryState ground then holds the items the player sees in the
+			// bottom pane (read via inventory_ground).
+			SoldiersState* st = findState<SoldiersState>(_game);
+			if (!st)
+			{
+				resp["error"] = "no SoldiersState in state stack";
+			}
+			else
+			{
+				st->btnInventoryClick(nullptr);
+				resp["opened"] = (findState<InventoryState>(_game) != nullptr);
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "inventory_ground")
+		{
+			// Read-only: the items on the base-inventory ground tile = the
+			// "bottom pane" the player sees. Requires an open base inventory
+			// (soldiers_inventory first).
+			SavedGame* invSg = _game->getSavedGame();
+			SavedBattleGame* bg = invSg ? invSg->getSavedBattle() : nullptr;
+			if (!bg)
+			{
+				resp["error"] = "no battle/inventory active";
+			}
+			else
+			{
+				Tile* ground = bg->getTile(0);
+				Json::Value items(Json::objectValue);
+				int total = 0;
+				if (ground)
+				{
+					for (auto* bi : *ground->getInventory())
+					{
+						std::string t = bi->getRules()->getType();
+						items[t] = items.get(t, 0).asInt() + 1;
+						total++;
+					}
+				}
+				// items carried by player units (on soldiers), to check
+				// conservation: ground + carried should equal what storage had.
+				Json::Value carried(Json::objectValue);
+				int carriedTotal = 0, units = 0;
+				for (auto* u : *bg->getUnits())
+				{
+					if (u->getFaction() != FACTION_PLAYER) continue;
+					units++;
+					for (auto* bi : *u->getInventory())
+					{
+						std::string t = bi->getRules()->getType();
+						carried[t] = carried.get(t, 0).asInt() + 1;
+						carriedTotal++;
+					}
+				}
+				// Every BattleItem instance in the inventory battle (ground +
+				// carried + loaded-into-weapon ammo), to detect true duplication
+				// independent of how items are distributed across soldiers.
+				Json::Value all(Json::objectValue);
+				int allTotal = 0;
+				for (auto* bi : *bg->getItems())
+				{
+					std::string t = bi->getRules()->getType();
+					all[t] = all.get(t, 0).asInt() + 1;
+					allTotal++;
+				}
+				resp["items"] = items;
+				resp["total"] = total;
+				resp["carried"] = carried;
+				resp["carriedTotal"] = carriedTotal;
+				resp["units"] = units;
+				resp["all"] = all;
+				resp["allTotal"] = allTotal;
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "incoming_transfers")
+		{
+			// Read a base's pending incoming transfers (item type -> total qty and
+			// soldier count), so a transfer can be checked as "en route" without
+			// advancing game time.
+			std::string tbase = req.get("base", "").asString();
+			Base* target = nullptr;
+			if (_game->getSavedGame())
+			{
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					if (tbase.empty() ? (base->_coopBase == false && base->_coopIcon == false) : base->getName() == tbase)
+					{ target = base; break; }
+				}
+			}
+			if (!target)
+				resp["error"] = "base not found";
+			else
+			{
+				Json::Value items(Json::objectValue);
+				int soldiers = 0;
+				for (auto* t : *target->getTransfers())
+				{
+					if (t->getType() == TRANSFER_ITEM && t->getItems())
+						items[t->getItems()->getType()] = items.get(t->getItems()->getType(), 0).asInt() + t->getQuantity();
+					else if (t->getType() == TRANSFER_SOLDIER)
+						soldiers++;
+				}
+				resp["items"] = items;
+				resp["soldiers"] = soldiers;
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "give_layout")
+		{
+			// Test helper: give every soldier at a base an equipment-layout entry
+			// for <item> (optionally capped at <count> soldiers). Reproduces the
+			// state a player creates by equipping soldiers - the layout reserves
+			// the item, but (as in the real game) base storage is NOT decremented,
+			// so the item is double-counted until a battle actually consumes it.
+			std::string layoutBase = req.get("base", "").asString();
+			bool wantCoop = req.get("coop", false).asBool();
+			std::string itemName = req.get("item", "").asString();
+			int count = req.get("count", -1).asInt();
+			std::string slotName = req.get("slot", "belt").asString();  // belt|right|left
+			std::string onlyName = req.get("name", "").asString();      // limit to soldiers matching this
+			Base* target = nullptr;
+			if (_game->getSavedGame())
+			{
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					bool match;
+					if (wantCoop) match = base->_coopBase;
+					else if (!layoutBase.empty()) match = (base->getName() == layoutBase);
+					else match = (base->_coopBase == false && base->_coopIcon == false);
+					if (match) { target = base; break; }
+				}
+			}
+			const RuleItem* rule = itemName.empty() ? nullptr : _game->getMod()->getItem(itemName, false);
+			if (!target)
+				resp["error"] = "base not found";
+			else if (!rule)
+				resp["error"] = "unknown item: " + itemName;
+			else
+			{
+				auto* slot = _game->getMod()->getInventoryBelt();
+				if (slotName == "right") slot = _game->getMod()->getInventoryRightHand();
+				else if (slotName == "left") slot = _game->getMod()->getInventoryLeftHand();
+				int dummyId = 0;
+				int given = 0;
+				for (auto* s : *target->getSoldiers())
+				{
+					if (!onlyName.empty() && s->getName().find(onlyName) == std::string::npos) continue;
+					if (count >= 0 && given >= count) break;
+					BattleItem tmp(rule, &dummyId);
+					tmp.setSlot(slot);
+					tmp.setSlotX(0);
+					tmp.setSlotY(0);
+					s->getEquipmentLayout()->push_back(new EquipmentLayoutItem(&tmp));
+					given++;
+				}
+				resp["given"] = given;
+				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "transfer_to_coop_base")
+		{
+			// Vanilla base->base transfer of one soldier to a co-op base (no
+			// ownership change), driven through the real TransferItemsState /
+			// completeTransfer path. This is the "transfer" (distinct from the
+			// "gift" ownership change).
+			std::string name = req.get("name", "").asString();
+			std::string toBaseName = req.get("toBase", "").asString();
+			Base* baseFrom = nullptr;
+			Soldier* soldier = nullptr;
+			Base* baseTo = nullptr;
+			if (_game->getSavedGame())
+			{
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					if (base->_coopBase == false && base->_coopIcon == false)
+					{
+						for (auto* s : *base->getSoldiers())
+						{
+							if (s->getName().find(name) != std::string::npos) { soldier = s; baseFrom = base; break; }
+						}
+					}
+					if (soldier) break;
+				}
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					if (base->_coopBase && (toBaseName.empty() || base->getName() == toBaseName)) { baseTo = base; break; }
+				}
+				if (!baseTo)
+				{
+					for (auto* base : *_game->getSavedGame()->getBases())
+					{
+						if (base->_coopIcon && (toBaseName.empty() || base->getName() == toBaseName)) { baseTo = base; break; }
+					}
+				}
+			}
+			if (!soldier)
+				resp["error"] = "soldier not found in own base: " + name;
+			else if (!baseTo)
+				resp["error"] = "coop dest base not found: " + toBaseName;
+			else
+			{
+				resp["toBase"] = baseTo->getName();
+				resp["toBaseCoopBase"] = baseTo->_coopBase;
+				resp["toBaseCoopIcon"] = baseTo->_coopIcon;
+				TransferItemsState* st = new TransferItemsState(baseFrom, baseTo, nullptr);
+				bool ok = st->transferSoldierNow(soldier);
+				delete st;
+				resp["transferred"] = ok;
+				resp["ok"] = ok;
+				if (!ok) resp["error"] = "soldier not a transferable row";
+			}
+		}
+		else if (cmd == "set_coop_base")
+		{
+			// Test helper: force a soldier's coopBase field. A value != -1 makes
+			// the own-base SoldiersState treat it as a foreign/guest soldier and
+			// strip it from the editable roster (reproducing the own-base variant
+			// of issue #33 without a cross-machine transfer).
+			std::string name = req.get("name", "").asString();
+			int value = req.get("value", -1).asInt();
+			Soldier* found = nullptr;
+			if (_game->getSavedGame())
+			{
+				for (auto* base : *_game->getSavedGame()->getBases())
+				{
+					for (auto* s : *base->getSoldiers())
+					{
+						if (s->getName().find(name) != std::string::npos) { found = s; break; }
+					}
+					if (found) break;
+				}
+			}
+			if (!found)
+				resp["error"] = "soldier not found: " + name;
+			else
+			{
+				found->setCoopBase(value);
+				resp["ok"] = true;
+			}
+		}
 		else if (cmd == "visit_coop_base")
 		{
 			std::string baseName = req.get("base", "").asString();
@@ -1400,7 +1721,7 @@ std::string TestServer::execute(const std::string& line)
 				resp["error"] = "no BasescapeState in state stack";
 			}
 		}
-		else if (cmd == "transfer_targets")
+		else if (cmd == "gift_targets")
 		{
 			// What the transfer dialog would offer for this soldier - lets
 			// tests validate owner resolution + button names without UI.
@@ -1427,7 +1748,7 @@ std::string TestServer::execute(const std::string& line)
 			}
 			else
 			{
-				int currentOwner = TransferSoldierMenu::resolveOwnerId(found);
+				int currentOwner = GiftSoldierMenu::resolveOwnerId(found);
 				int localPlayerId = connectionTCP::getHost() ? 0 : 1;
 				Json::Value targets(Json::arrayValue);
 				for (int playerId = 0; playerId <= 1; ++playerId)
@@ -1446,7 +1767,7 @@ std::string TestServer::execute(const std::string& line)
 				resp["ok"] = true;
 			}
 		}
-		else if (cmd == "open_transfer_dialog")
+		else if (cmd == "open_gift_dialog")
 		{
 			std::string name = req.get("name", "").asString();
 			Soldier* found = nullptr;
@@ -1467,7 +1788,7 @@ std::string TestServer::execute(const std::string& line)
 			}
 			if (found)
 			{
-				_game->pushState(new TransferSoldierMenu(found, TransferSoldierMenu::resolveOwnerId(found)));
+				_game->pushState(new GiftSoldierMenu(found, GiftSoldierMenu::resolveOwnerId(found)));
 				resp["ok"] = true;
 			}
 			else
@@ -1507,7 +1828,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "show_notice")
 		{
-			_game->pushState(new TransferNoticeState(req.get("message", "test notice").asString()));
+			_game->pushState(new GiftNoticeState(req.get("message", "test notice").asString()));
 			resp["ok"] = true;
 		}
 		else if (cmd == "get_notices")
@@ -1516,7 +1837,7 @@ std::string TestServer::execute(const std::string& line)
 			// PRD-13: left inline - appends every match's category into a container, not a find
 			for (auto* s : _game->getStates())
 			{
-				if (auto* n = dynamic_cast<TransferNoticeState*>(s))
+				if (auto* n = dynamic_cast<GiftNoticeState*>(s))
 				{
 					notices.append(n->getCategory());
 				}
@@ -1526,7 +1847,7 @@ std::string TestServer::execute(const std::string& line)
 		}
 		else if (cmd == "dismiss_notice")
 		{
-			TransferNoticeState* st = findState<TransferNoticeState>(_game);
+			GiftNoticeState* st = findState<GiftNoticeState>(_game);
 			if (st)
 			{
 				st->btnOkClick(nullptr);
@@ -1534,12 +1855,12 @@ std::string TestServer::execute(const std::string& line)
 			}
 			else
 			{
-				resp["error"] = "no TransferNoticeState in state stack";
+				resp["error"] = "no GiftNoticeState in state stack";
 			}
 		}
 		else if (cmd == "cancel_dialog")
 		{
-			TransferSoldierMenu* st = findState<TransferSoldierMenu>(_game);
+			GiftSoldierMenu* st = findState<GiftSoldierMenu>(_game);
 			if (st)
 			{
 				st->btnCancelClick(nullptr);
@@ -1547,7 +1868,7 @@ std::string TestServer::execute(const std::string& line)
 			}
 			else
 			{
-				resp["error"] = "no TransferSoldierMenu in state stack";
+				resp["error"] = "no GiftSoldierMenu in state stack";
 			}
 		}
 		else if (cmd == "get_palettes")
@@ -1573,7 +1894,7 @@ std::string TestServer::execute(const std::string& line)
 			resp["states"] = states;
 			resp["ok"] = true;
 		}
-		else if (cmd == "transfer")
+		else if (cmd == "gift")
 		{
 			std::string name = req.get("name", "").asString();
 			int owner = req.get("owner", -1).asInt();
@@ -1606,7 +1927,7 @@ std::string TestServer::execute(const std::string& line)
 				}
 				else
 				{
-					coop->transferSoldierOwnership(found, owner, true);
+					coop->giftSoldier(found, owner, true);
 					resp["soldier"] = soldierToJson(found);
 					resp["ok"] = true;
 				}
@@ -1860,6 +2181,11 @@ std::string TestServer::execute(const std::string& line)
 			else if (name == "oxceGeoAutosaveFrequency")
 			{
 				Options::oxceGeoAutosaveFrequency = req.get("value", 0).asInt();
+				resp["ok"] = true;
+			}
+			else if (name == "oxceAlternateCraftEquipmentManagement")
+			{
+				Options::oxceAlternateCraftEquipmentManagement = req.get("value", false).asBool();
 				resp["ok"] = true;
 			}
 			else

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -58,7 +58,7 @@
 
 #include "PasswordCheckMenu.h"
 #include "ModCheckMenu.h"
-#include "TransferNoticeState.h"
+#include "GiftNoticeState.h"
 #include "connectionUDP/connection_udp_glue.h"
 
 #include "../Savegame/BaseFacility.h"
@@ -1024,7 +1024,7 @@ void connectionTCP::loopData()
 	}
 }
 
-void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, bool broadcast)
+void connectionTCP::giftSoldier(Soldier* soldier, int newOwnerId, bool broadcast)
 {
 
 	if (!soldier || !_game->getSavedGame())
@@ -1037,7 +1037,7 @@ void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, b
 
 	int localPlayerId = getHost() ? 0 : 1;
 
-	Log(LOG_INFO) << "[coop-transfer] transferSoldierOwnership '" << soldier->getName() << "' id=" << soldier->getId()
+	Log(LOG_INFO) << "[coop-gift] giftSoldier '" << soldier->getName() << "' id=" << soldier->getId()
 	              << " newOwner=" << newOwnerId << " localPlayer=" << localPlayerId
 	              << " broadcast=" << (broadcast ? 1 : 0)
 	              << " inBattle=" << (_game->getSavedGame()->getSavedBattle() ? 1 : 0);
@@ -1069,7 +1069,7 @@ void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, b
 
 					// Immediate control flip on the peer's battle too.
 					Json::Value obj;
-					obj["state"] = "transferSoldier";
+					obj["state"] = "giftSoldier";
 					obj["soldier_id"] = soldier->getId();
 					obj["owner"] = newOwnerId;
 					obj["unit_id"] = unit->getId();
@@ -1086,7 +1086,7 @@ void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, b
 
 		if (broadcast && newOwnerId != localPlayerId)
 		{
-			_pendingSoldierTransfers.push_back(std::make_pair(soldier, newOwnerId));
+			_pendingSoldierGifts.push_back(std::make_pair(soldier, newOwnerId));
 		}
 
 	}
@@ -1096,10 +1096,10 @@ void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, b
 		// The soldier's object lives in its owner's save (guest-soldier
 		// model): hand it to the peer and drop it from our world. It keeps
 		// its station base, so it stays "in" the base it is in right now.
-		sendSoldierTransferPacket(soldier, newOwnerId);
+		sendSoldierGiftPacket(soldier, newOwnerId);
 		removeSoldierFromLocalBases(soldier);
-		_transferredSoldiers.push_back(soldier);
-		_transferredAwaySoldierIds.insert(soldier->getId());
+		_giftedSoldiers.push_back(soldier);
+		_giftedAwaySoldierIds.insert(soldier->getId());
 
 		// keep the host-side client blob fresh (no-op on the host itself)
 		pushProgressToHostSilently();
@@ -1108,10 +1108,10 @@ void connectionTCP::transferSoldierOwnership(Soldier* soldier, int newOwnerId, b
 
 }
 
-void connectionTCP::processPendingSoldierTransfers()
+void connectionTCP::processPendingSoldierGifts()
 {
 
-	// Replay physical transfers that arrived while our world was swapped out
+	// Replay physical gifts that arrived while our world was swapped out
 	// for the peer's base view OR for a coop battle. The flags clear before
 	// LoadGameState has actually restored our save, so also require that an
 	// own (non-mirror) base is present, that no own-world reload is still
@@ -1123,7 +1123,7 @@ void connectionTCP::processPendingSoldierTransfers()
 	State* topState = _game->getStates().empty() ? nullptr : _game->getStates().back();
 	bool ownWorldLoadPending = (dynamic_cast<LoadGameState*>(topState) != nullptr);
 
-	if (!_pendingIncomingTransfers.empty()
+	if (!_pendingIncomingGifts.empty()
 	    && _game->getCoopMod()->playerInsideCoopBase == false
 	    && _game->getCoopMod()->coopMissionEnd == false
 	    && !ownWorldLoadPending
@@ -1146,26 +1146,26 @@ void connectionTCP::processPendingSoldierTransfers()
 	{
 
 		std::vector<Json::Value> replay;
-		replay.swap(_pendingIncomingTransfers);
+		replay.swap(_pendingIncomingGifts);
 
 		for (auto& obj : replay)
 		{
-			onTCPMessage("transferSoldier", obj);
+			onTCPMessage("giftSoldier", obj);
 		}
 
 	}
 
-	if (_game->getSavedGame() && !_game->getSavedGame()->getSavedBattle() && getCoopStatic() && getCoopCampaign() && _pendingSoldierTransfers.empty())
+	if (_game->getSavedGame() && !_game->getSavedGame()->getSavedBattle() && getCoopStatic() && getCoopCampaign() && _pendingSoldierGifts.empty())
 	{
 
-		// Targeted sweep: a stale copy of a soldier we transferred away this
+		// Targeted sweep: a stale copy of a soldier we gifted away this
 		// session can resurrect when the pre-visit "basehost" snapshot is
-		// restored after a transfer made while viewing the peer's base. Park
+		// restored after a gift made while viewing the peer's base. Park
 		// exactly those (matched by id AND still peer-owned - a soldier
 		// traded back to us has our owner id and is left alone). Deliberately
 		// NOT a blanket owner check: legacy saves carry stale ownerPlayerId
 		// values on unrelated soldiers.
-		if (!_transferredAwaySoldierIds.empty())
+		if (!_giftedAwaySoldierIds.empty())
 		{
 
 			int localPlayerId = getHost() ? 0 : 1;
@@ -1180,9 +1180,9 @@ void connectionTCP::processPendingSoldierTransfers()
 
 					Soldier* s = *it;
 
-					if (_transferredAwaySoldierIds.count(s->getId()) != 0 && s->getOwnerPlayerId() != 999 && s->getOwnerPlayerId() != localPlayerId)
+					if (_giftedAwaySoldierIds.count(s->getId()) != 0 && s->getOwnerPlayerId() != 999 && s->getOwnerPlayerId() != localPlayerId)
 					{
-						_transferredSoldiers.push_back(s);
+						_giftedSoldiers.push_back(s);
 						it = soldiers.erase(it);
 					}
 					else
@@ -1198,7 +1198,7 @@ void connectionTCP::processPendingSoldierTransfers()
 
 	}
 
-	if (_pendingSoldierTransfers.empty())
+	if (_pendingSoldierGifts.empty())
 	{
 		return;
 	}
@@ -1209,17 +1209,17 @@ void connectionTCP::processPendingSoldierTransfers()
 		return;
 	}
 
-	for (auto& pending : _pendingSoldierTransfers)
+	for (auto& pending : _pendingSoldierGifts)
 	{
 
 		Soldier* soldier = pending.first;
 
 		// Died during the mission: stays in the giver's memorial. The physical
 		// hand-off never happened, so undo the in-battle ownership flip that
-		// transferSoldierOwnership applied - otherwise the fallen soldier would
+		// giftSoldier applied - otherwise the fallen soldier would
 		// sit in the giver's Hall of Honour still flagged as the peer's
 		// (coop/ownerPlayerId), and the receiver never gets a memorial entry
-		// (its transfer was skipped). Reset to a plain own-soldier so the
+		// (its gift was skipped). Reset to a plain own-soldier so the
 		// giver's memorial records it correctly.
 		if (soldier->getDeath())
 		{
@@ -1228,11 +1228,11 @@ void connectionTCP::processPendingSoldierTransfers()
 			continue;
 		}
 
-		// Auto-keep an in-battle-transferred soldier on the craft it was
+		// Auto-keep an in-battle-gifted soldier on the craft it was
 		// deployed on, mirroring how a giver's own crew stays aboard their
 		// craft after a mission. The guest lives in the receiver's world, so
 		// the live Craft* pointer cannot survive the hand-off (it is detached
-		// in sendSoldierTransferPacket) - translate it into the guest CoopCraft
+		// in sendSoldierGiftPacket) - translate it into the guest CoopCraft
 		// mechanism, which the receiver's mission-end reload and battle merge
 		// honour (CoopCraft = the host craft id, CoopCraftType = its type).
 		// A wounded survivor is deliberately left unassigned so it is not flown
@@ -1251,14 +1251,14 @@ void connectionTCP::processPendingSoldierTransfers()
 			}
 		}
 
-		sendSoldierTransferPacket(soldier, pending.second);
+		sendSoldierGiftPacket(soldier, pending.second);
 		removeSoldierFromLocalBases(soldier);
-		_transferredSoldiers.push_back(soldier);
-		_transferredAwaySoldierIds.insert(soldier->getId());
+		_giftedSoldiers.push_back(soldier);
+		_giftedAwaySoldierIds.insert(soldier->getId());
 
 	}
 
-	_pendingSoldierTransfers.clear();
+	_pendingSoldierGifts.clear();
 
 	// transfers happened while our world was busy - sync the blob now
 	pushProgressToHostSilently();
@@ -1298,7 +1298,7 @@ void connectionTCP::pushProgressToHostSilently()
 	obj["state"] = "SEND_FILE_HOST_TRUE_SAVE_PROGRESS";
 	sendTCPPacketData(obj.toStyledString());
 
-	Log(LOG_INFO) << "[coop-transfer] pushed client progress to host (" << filename << ")";
+	Log(LOG_INFO) << "[coop-gift] pushed client progress to host (" << filename << ")";
 
 }
 
@@ -1367,20 +1367,20 @@ void connectionTCP::syncOwnWorldGuestCraft(int coopBaseId, const std::map<std::s
 	if (changed)
 	{
 		ownWorld->saveCoopToMemory(filename, _game->getMod(), filename);
-		Log(LOG_INFO) << "[coop-transfer] synced guest craft assignments into own-world blob (" << filename << ")";
+		Log(LOG_INFO) << "[coop-gift] synced guest craft assignments into own-world blob (" << filename << ")";
 	}
 
 	delete ownWorld;
 
 }
 
-void connectionTCP::resetTransferSessionState()
+void connectionTCP::resetGiftSessionState()
 {
 
-	_pendingSoldierTransfers.clear();
-	_pendingIncomingTransfers.clear();
-	_seenTransferPacketIds.clear();
-	_transferredAwaySoldierIds.clear();
+	_pendingSoldierGifts.clear();
+	_pendingIncomingGifts.clear();
+	_seenGiftPacketIds.clear();
+	_giftedAwaySoldierIds.clear();
 
 	// PRD-06 C5: a different world is being loaded - abort any armed deferred
 	// host save so a late client blob cannot rewrite the (now stale) named save.
@@ -1425,7 +1425,7 @@ void connectionTCP::writePendingHostSave()
 
 }
 
-void connectionTCP::sendSoldierTransferPacket(Soldier* soldier, int newOwnerId)
+void connectionTCP::sendSoldierGiftPacket(Soldier* soldier, int newOwnerId)
 {
 
 	// Which base is the soldier stationed at? If it is already a guest at the
@@ -1466,12 +1466,12 @@ void connectionTCP::sendSoldierTransferPacket(Soldier* soldier, int newOwnerId)
 
 	// Durable unique id: player tag + wall-clock + counter. Receipts persist
 	// in saves across sessions, so a per-run counter alone would collide.
-	long long xferId = (getHost() ? 1000000000000000LL : 2000000000000000LL) + (long long)time(0) * 1000LL + (++_transferSendCounter % 1000);
+	long long xferId = (getHost() ? 1000000000000000LL : 2000000000000000LL) + (long long)time(0) * 1000LL + (++_giftSendCounter % 1000);
 
 	std::string yaml = writer.emit().yaml;
 
 	Json::Value obj;
-	obj["state"] = "transferSoldier";
+	obj["state"] = "giftSoldier";
 	obj["soldier_id"] = soldier->getId();
 	obj["owner"] = newOwnerId;
 	obj["unit_id"] = -1;
@@ -1481,7 +1481,7 @@ void connectionTCP::sendSoldierTransferPacket(Soldier* soldier, int newOwnerId)
 
 	std::string packet = obj.toStyledString();
 
-	Log(LOG_INFO) << "[coop-transfer] SEND soldier '" << soldier->getName() << "' id=" << soldier->getId()
+	Log(LOG_INFO) << "[coop-gift] SEND soldier '" << soldier->getName() << "' id=" << soldier->getId()
 	              << " newOwner=" << newOwnerId << " stationBaseId=" << stationBaseId
 	              << " packetBytes=" << packet.size();
 
@@ -1537,7 +1537,7 @@ void connectionTCP::updateCoopTask()
 	// coop: finish queued in-battle soldier transfers as soon as no battle is
 	// active (fallback for the client, which may not run the host's
 	// coopMissionEnd path in GeoscapeState).
-	processPendingSoldierTransfers();
+	processPendingSoldierGifts();
 
 	if (connectionTCP::saveError == true)
 	{
@@ -2971,7 +2971,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 
 	}
 
-	if (stateString == "transferSoldier")
+	if (stateString == "giftSoldier")
 	{
 
 		if (_game->getSavedGame())
@@ -2981,7 +2981,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 			int owner = obj["owner"].asInt();
 			int unit_id = obj["unit_id"].asInt();
 
-			Log(LOG_INFO) << "[coop-transfer] RECV transferSoldier id=" << soldier_id << " owner=" << owner
+			Log(LOG_INFO) << "[coop-gift] RECV giftSoldier id=" << soldier_id << " owner=" << owner
 			              << " hasYaml=" << (obj.isMember("soldier_yaml") ? 1 : 0)
 			              << " inBattle=" << (_game->getSavedGame()->getSavedBattle() ? 1 : 0);
 
@@ -2994,14 +2994,14 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 				// apply for later, but ALSO drop a display copy into the
 				// visited base so the new owner sees the soldier right away,
 				// and show the notification now.
-				Log(LOG_INFO) << "[coop-transfer] RECV deferred (viewing peer base)";
+				Log(LOG_INFO) << "[coop-gift] RECV deferred (viewing peer base)";
 
 				try
 				{
 
 					int stationBaseId = obj["station_base_id"].asInt();
 
-					YAML::YamlRootNodeReader reader(YAML::YamlString{obj["soldier_yaml"].asString()}, "transferSoldier");
+					YAML::YamlRootNodeReader reader(YAML::YamlString{obj["soldier_yaml"].asString()}, "giftSoldier");
 					auto soldierReader = reader["soldier"];
 					std::string type = soldierReader["type"].readVal(_game->getMod()->getSoldiersList().front());
 					std::string soldierName = soldierReader["name"].readVal(std::string());
@@ -3033,17 +3033,17 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 					if (!obj.get("notified", false).asBool())
 					{
 						std::string baseName = visited ? visited->getName() : "their base";
-						_game->pushState(new TransferNoticeState(getCurrentClientName() + " transferred ownership of " + soldierName + " to you at base " + baseName));
+						_game->pushState(new GiftNoticeState(getCurrentClientName() + " gifted " + soldierName + " to you at base " + baseName));
 						obj["notified"] = true;
 					}
 
 				}
 				catch (const std::exception& e)
 				{
-					Log(LOG_INFO) << "[coop-transfer] RECV display-copy failed: " << e.what();
+					Log(LOG_INFO) << "[coop-gift] RECV display-copy failed: " << e.what();
 				}
 
-				_pendingIncomingTransfers.push_back(obj);
+				_pendingIncomingGifts.push_back(obj);
 
 			}
 			else if (obj.isMember("soldier_yaml")
@@ -3054,15 +3054,15 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 				// Coop battle just ended (or is still tearing down): our live
 				// SavedGame is still the HOST's battle world - the own-world
 				// reload (GeoscapeState::init) has not run yet. Applying the
-				// physical transfer now would match the giver's real base in
+				// physical gift now would match the giver's real base in
 				// that throwaway world (coopBase cleared to -1, soldier deleted
 				// by the post-battle cleanup) and the follow-up client-progress
 				// push would upload the host world as our own-world blob. Defer
-				// and let processPendingSoldierTransfers() replay it once our
+				// and let processPendingSoldierGifts() replay it once our
 				// own world is restored (host base is a mirror there, so the
 				// soldier correctly stays a guest at station_base_id).
-				Log(LOG_INFO) << "[coop-transfer] RECV deferred (mission-end swapped world)";
-				_pendingIncomingTransfers.push_back(obj);
+				Log(LOG_INFO) << "[coop-gift] RECV deferred (mission-end swapped world)";
+				_pendingIncomingGifts.push_back(obj);
 
 			}
 			else if (obj.isMember("soldier_yaml"))
@@ -3075,7 +3075,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 				try
 				{
 
-					YAML::YamlRootNodeReader reader(YAML::YamlString{obj["soldier_yaml"].asString()}, "transferSoldier");
+					YAML::YamlRootNodeReader reader(YAML::YamlString{obj["soldier_yaml"].asString()}, "giftSoldier");
 					auto soldierReader = reader["soldier"];
 
 					std::string type = soldierReader["type"].readVal(_game->getMod()->getSoldiersList().front());
@@ -3119,8 +3119,8 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 						// the packet in that window - defer and replay.
 						if (!targetBase)
 						{
-							Log(LOG_INFO) << "[coop-transfer] RECV deferred (no own base in current save)";
-							_pendingIncomingTransfers.push_back(obj);
+							Log(LOG_INFO) << "[coop-gift] RECV deferred (no own base in current save)";
+							_pendingIncomingGifts.push_back(obj);
 						}
 						else
 						{
@@ -3129,14 +3129,14 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 						// packet id (in-memory: with the host save as the single
 						// authority, packets are never re-sent across sessions).
 						long long xferId = obj.get("xfer_id", 0).asInt64();
-						bool exists = (xferId != 0 && _seenTransferPacketIds.count(xferId) != 0);
+						bool exists = (xferId != 0 && _seenGiftPacketIds.count(xferId) != 0);
 
 						if (xferId != 0)
 						{
-							_seenTransferPacketIds.insert(xferId);
+							_seenGiftPacketIds.insert(xferId);
 						}
 
-						Log(LOG_INFO) << "[coop-transfer] RECV type=" << type << " exists=" << (exists ? 1 : 0)
+						Log(LOG_INFO) << "[coop-gift] RECV type=" << type << " exists=" << (exists ? 1 : 0)
 						              << " homeBase=" << (homeBase ? homeBase->getName() : "none")
 						              << " targetBase=" << targetBase->getName()
 						              << " stationBaseId=" << stationBaseId;
@@ -3200,7 +3200,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 								targetBase->base_oldsoldiers2.push_back(soldier);
 							}
 
-							Log(LOG_INFO) << "[coop-transfer] RECV added soldier '" << soldier->getName()
+							Log(LOG_INFO) << "[coop-gift] RECV added soldier '" << soldier->getName()
 							              << "' id=" << soldier->getId() << " to base '" << targetBase->getName()
 							              << "' coopBase=" << soldier->getCoopBase();
 
@@ -3227,7 +3227,7 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 									}
 								}
 
-								_game->pushState(new TransferNoticeState(getCurrentClientName() + " transferred ownership of " + soldier->getName() + " to you at base " + baseName));
+								_game->pushState(new GiftNoticeState(getCurrentClientName() + " gifted " + soldier->getName() + " to you at base " + baseName));
 
 							}
 
@@ -3238,13 +3238,13 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 					}
 					else
 					{
-						Log(LOG_INFO) << "[coop-transfer] RECV unknown soldier type " << type;
+						Log(LOG_INFO) << "[coop-gift] RECV unknown soldier type " << type;
 					}
 
 				}
 				catch (const std::exception& e)
 				{
-					Log(LOG_INFO) << "[coop-transfer] RECV failed to load soldier yaml: " << e.what();
+					Log(LOG_INFO) << "[coop-gift] RECV failed to load soldier yaml: " << e.what();
 				}
 
 			}

--- a/src/CoopMod/connectionTCP.h
+++ b/src/CoopMod/connectionTCP.h
@@ -645,7 +645,7 @@ class connectionTCP
 	static bool canRemoveManuallyAddedServer;
 	static bool isInfoboxClosed;
 
-	// Permanently transfers a soldier to another player (0 = host, 1 = client).
+	// Permanently gifts a soldier to another player (0 = host, 1 = client).
 	// Follows the guest-soldier model: a soldier's object lives in its OWNER's
 	// save, tagged with coopBase = the station base's coop id when that base
 	// belongs to the other player (-1 when stationed at one of the owner's own
@@ -653,46 +653,46 @@ class connectionTCP
 	// recreated in the receiver's save, keeping the same station base - so it
 	// stays "in" the base it was in, and shows up when the new owner views
 	// that base. During battle only the control flags flip immediately; the
-	// physical move is queued and runs after the mission ends. Transfers
-	// overwrite unconditionally, so soldiers can be traded back and forth.
-	void transferSoldierOwnership(Soldier* soldier, int newOwnerId, bool broadcast);
-	// Completes queued in-battle transfers once no battle is active. Must run
+	// physical move is queued and runs after the mission ends. Gifts
+	// overwrite unconditionally, so soldiers can be gifted back and forth.
+	void giftSoldier(Soldier* soldier, int newOwnerId, bool broadcast);
+	// Completes queued in-battle gifts once no battle is active. Must run
 	// before the post-battle coop cleanup (GeoscapeState calls it first).
-	void processPendingSoldierTransfers();
+	void processPendingSoldierGifts();
 
   private:
 	// Serializes the soldier (with its station base id) and sends the
-	// physical-transfer packet to the peer.
-	void sendSoldierTransferPacket(Soldier* soldier, int newOwnerId);
+	// physical-gift packet to the peer.
+	void sendSoldierGiftPacket(Soldier* soldier, int newOwnerId);
 	// Erases the soldier pointer from every base roster (including the
 	// SoldiersState/CraftSoldiersState base_oldsoldiers snapshots).
 	void removeSoldierFromLocalBases(Soldier* soldier);
-	// In-battle transfers waiting for the mission to end: soldier + new owner.
-	std::vector<std::pair<Soldier*, int> > _pendingSoldierTransfers;
-	// Soldiers transferred away are parked here instead of deleted: UI states
+	// In-battle gifts waiting for the mission to end: soldier + new owner.
+	std::vector<std::pair<Soldier*, int> > _pendingSoldierGifts;
+	// Soldiers gifted away are parked here instead of deleted: UI states
 	// (sort snapshots, open dialogs) may still hold pointers to them.
-	std::vector<Soldier*> _transferredSoldiers;
-	// Ids of soldiers transferred away this session. A stale copy of one of
+	std::vector<Soldier*> _giftedSoldiers;
+	// Ids of soldiers gifted away this session. A stale copy of one of
 	// these can resurrect when the pre-visit "basehost" snapshot is restored;
-	// the sweep in processPendingSoldierTransfers() parks exactly those (and
+	// the sweep in processPendingSoldierGifts() parks exactly those (and
 	// nothing else - legacy saves carry unrelated ownerPlayerId values).
-	std::unordered_set<int> _transferredAwaySoldierIds;
-	// Counter feeding the unique per-packet transfer id, plus the in-memory
+	std::unordered_set<int> _giftedAwaySoldierIds;
+	// Counter feeding the unique per-packet gift id, plus the in-memory
 	// duplicate-delivery guard (sufficient now: the host's save is the single
 	// authority, so packets are never re-sent across sessions).
-	int _transferSendCounter = 0;
-	std::unordered_set<long long> _seenTransferPacketIds;
-	// Incoming physical transfers received while our SavedGame is swapped out
+	int _giftSendCounter = 0;
+	std::unordered_set<long long> _seenGiftPacketIds;
+	// Incoming physical gifts received while our SavedGame is swapped out
 	// (viewing the peer's base, playerInsideCoopBase). Applying them then
 	// would mutate the temporary peer world and be discarded on exit - the
 	// soldier would vanish on both machines. Replayed once our world is back.
-	std::vector<Json::Value> _pendingIncomingTransfers;
+	std::vector<Json::Value> _pendingIncomingGifts;
   public:
 	// Single-authority model: the HOST's .sav embeds the latest client-world
 	// blob (see SavedGame::save/load), so loading a host save atomically
 	// restores BOTH players' rosters; the client re-fetches its world from
 	// the host on reconnect. To keep the embedded blob fresh, the client
-	// silently pushes its progress to the host after every soldier transfer.
+	// silently pushes its progress to the host after every soldier gift.
 	void pushProgressToHostSilently();
 	// Fix B (Bug 1): when the client assigns/unassigns its guest soldiers to a
 	// host craft via the mirror-base UI, the assignment is written only into the
@@ -704,10 +704,10 @@ class connectionTCP
 	// to the host) so the assignment survives the mission-end reload.
 	// assignments maps a guest's CoopName to {CoopCraft, CoopCraftType}.
 	void syncOwnWorldGuestCraft(int coopBaseId, const std::map<std::string, std::pair<int, std::string>>& assignments);
-	// Clears session transfer state (pending queues, dedup ids, away-ids)
+	// Clears session gift state (pending queues, dedup ids, away-ids)
 	// after a save load - stale in-memory state must never outlive the save
 	// that is now the authority.
-	void resetTransferSessionState();
+	void resetGiftSessionState();
 };
 
 }

--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -47,7 +47,7 @@
 #include "../fallthrough.h"
 
 #include "../CoopMod/CrashHandler.h" // coop
-#include "../CoopMod/TransferSoldierMenu.h" // coop
+#include "../CoopMod/GiftSoldierMenu.h" // coop
 #include "../CoopMod/TestServer.h" // coop test automation
 
 namespace OpenXcom
@@ -366,7 +366,7 @@ void Game::run()
 											{
 
 												// Campaign soldier: open the permanent-transfer dialog.
-												pushState(new TransferSoldierMenu(selectedUnit->getGeoscapeSoldier(), selectedUnit->getCoop()));
+												pushState(new GiftSoldierMenu(selectedUnit->getGeoscapeSoldier(), selectedUnit->getCoop()));
 
 											}
 											else

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -905,7 +905,7 @@ void GeoscapeState::init()
 	// below deletes other-player soldiers (the queue still references them).
 	if (_game->getCoopMod()->coopMissionEnd == true)
 	{
-		_game->getCoopMod()->processPendingSoldierTransfers();
+		_game->getCoopMod()->processPendingSoldierGifts();
 	}
 
 	// HOST AFTER THE BATTLE

--- a/src/Menu/LoadGameState.cpp
+++ b/src/Menu/LoadGameState.cpp
@@ -201,7 +201,7 @@ void LoadGameState::think()
 				s->load(_filename, _game->getMod(), _game->getLanguage());
 				// the loaded save is now the authority - drop stale
 				// in-memory transfer session state
-				_game->getCoopMod()->resetTransferSessionState();
+				_game->getCoopMod()->resetGiftSessionState();
 			}
 			else
 			{

--- a/src/OpenXcom.2010.vcxproj
+++ b/src/OpenXcom.2010.vcxproj
@@ -346,8 +346,8 @@
     <ClCompile Include="CoopMod\CrashHandler.cpp" />
     <ClCompile Include="CoopMod\OptionsMultiplayer.cpp" />
     <ClCompile Include="CoopMod\Profile.cpp" />
-    <ClCompile Include="CoopMod\TransferNoticeState.cpp" />
-    <ClCompile Include="CoopMod\TransferSoldierMenu.cpp" />
+    <ClCompile Include="CoopMod\GiftNoticeState.cpp" />
+    <ClCompile Include="CoopMod\GiftSoldierMenu.cpp" />
     <ClCompile Include="CoopMod\TestServer.cpp" />
     <ClCompile Include="CoopMod\AddServerMenu.cpp" />
     <ClCompile Include="CoopMod\DirectConnect.cpp" />
@@ -787,8 +787,8 @@
     <ClInclude Include="CoopMod\CrashHandler.h" />
     <ClInclude Include="CoopMod\OptionsMultiplayer.h" />
     <ClInclude Include="CoopMod\Profile.h" />
-    <ClInclude Include="CoopMod\TransferNoticeState.h" />
-    <ClInclude Include="CoopMod\TransferSoldierMenu.h" />
+    <ClInclude Include="CoopMod\GiftNoticeState.h" />
+    <ClInclude Include="CoopMod\GiftSoldierMenu.h" />
     <ClInclude Include="CoopMod\TestServer.h" />
     <ClInclude Include="..\libs\miniz\miniz.h" />
     <ClInclude Include="..\libs\rapidyaml\c4\allocator.hpp" />

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -181,6 +181,16 @@ void Base::syncTrade(std::string items, SavedGame *save, Mod *mod)
 
 			RuleItem *rule_item = mod->getItem(name);
 
+			// A 0-hour item transfer (the co-op "equipment travels with the
+			// soldier" path) lands immediately, matching the instant soldier
+			// move, instead of queuing as a timed transfer.
+			if (hour <= 0)
+			{
+				getStorageItems()->addItem(rule_item, amount);
+				delete t;
+				continue;
+			}
+
 			t->setItems(rule_item, amount);
 		}
 

--- a/tools/coop_test/README.md
+++ b/tools/coop_test/README.md
@@ -58,10 +58,10 @@ campaign each run.
 
 - `boot_check.py` - single-instance install smoke test.
 - `test_geoscape_sync.py` - two instances; geoscape host/client sync check.
-- `test_transfer_fresh.py` - soldier ownership transfer on a fresh campaign.
+- `test_gift_fresh.py` - gifting a soldier (ownership change) on a fresh campaign.
 - `test_bug_fixes.py` - owner resolution, notice display, dialog flicker, etc.
   Exposes `bootstrap_fresh_session()` and `own_base()` reused by other tests.
-- `test_transfer_rollback.py` - host-save-is-authority rollback, both directions.
+- `test_gift_rollback.py` - host-save-is-authority rollback of a gift, both directions.
 - `test_server_browser.py` - rendezvous-server combobox state (offline path).
 - `test_ufo_notice.py` - when one player detects a UFO, the peer gets the notice
   too (both `UfoDetectedState` popups); checks both directions.
@@ -77,6 +77,22 @@ campaign each run.
   world back (roster + markers intact).
 - `test_rejoin_flow.py` - mid-session hard-kill -> host freeze dialog ->
   direct rejoin (no lobby) -> RESUME; roster intact, zero-disk.
+- `test_coop_base_equip_visibility.py` - issue #33: items a player reserved by
+  equipping soldiers at a base must not appear as free/available equipment to a
+  peer visiting that base, nor to the owner when the reserving soldier is a
+  stripped co-op guest; checks all four host/client directions.
+- `test_coop_transferred_equipment.py` - vanilla-transferring an equipped
+  soldier to a peer base must not duplicate its equipment: the world-wide item
+  total is unchanged and the client-base equip screen shows the same number of
+  item instances to the visiting host as to the client (conservation).
+- `test_coop_transfer_equipment_option.py` - the "Alternate craft equipment
+  management" option drives transfer behaviour: OFF strips the soldier's gear
+  (empty layout at the peer base), ON keeps its loadout. Runs both modes.
+- `test_coop_transfer_equipment_counts.py` - with the option ON the gear's item
+  counts actually move, immediately (0-hour transfer, matching the instant
+  soldier move): the sending base's stored count drops and the receiving base's
+  stored count rises by the same amount, world total conserved. OFF moves
+  nothing.
 
 `session.py` is the shared campaign dance (`new_campaign` / `resume_campaign`
 / `assert_client_zero_disk`) used by every test.
@@ -94,9 +110,19 @@ campaign each run.
   `lobby_state`, `lobby_start_campaign`, `lobby_resume_campaign`,
   `coop_dialog_back`, `save_markers`, `lobby_ready` (legacy),
   `client_reload_progress`, `quit`.
-- Transfer / UI: `transfer`, `transfer_targets`, `rename_soldier`,
-  `open_soldiers`, `visit_coop_base`, `open_transfer_dialog`, `cancel_dialog`,
-  `show_notice`, `get_notices`, `dismiss_notice`, `get_palettes`.
+- Gift / UI: `gift` (change a soldier's owner), `gift_targets`,
+  `open_gift_dialog`, `rename_soldier`, `open_soldiers`, `soldiers_ok`,
+  `soldiers_inventory` (right-click-equip a base's soldiers), `inventory_ground`
+  (read the open inventory's ground pane: `items`=ground, `carried`=on units,
+  `all`=every instance incl. loaded ammo), `base_report` (storage + per-soldier
+  reserved layout items; `coop:true` picks the visited base), `give_layout`
+  (reserve an `item` on a base's soldiers, optional `slot`=belt|right|left and
+  `name` filter), `set_coop_base` (force a soldier's coopBase, e.g. to make it a
+  stripped guest), `transfer_to_coop_base` (vanilla base->base transfer of a
+  soldier to a peer base, no ownership change), `incoming_transfers` (a base's
+  pending incoming item/soldier transfers), `visit_coop_base`, `leave_base`,
+  `cancel_dialog`, `show_notice`, `get_notices`, `dismiss_notice`,
+  `get_palettes`.
 - Geoscape: `geo_state`, `geo_set_speed`, `dismiss_popup`, `craft_dispatch`,
   `confirm_landing`.
 - Battlescape: `close_briefing`, `battle_inventory`, `battle_state`,

--- a/tools/coop_test/test_bug_fixes.py
+++ b/tools/coop_test/test_bug_fixes.py
@@ -1,9 +1,9 @@
-"""Autonomous regression tests for the three transfer bugs:
+"""Autonomous regression tests for the three gift bugs:
 
-1. Transfer while the receiving player has a soldier list / the peer-base
+1. Gift while the receiving player has a soldier list / the peer-base
    view open must not lose the soldier.
-2. The transfer dialog must adopt its parent state's palette (no flicker).
-3. Owner resolution: a fresh soldier's transfer target list must show the
+2. The gift dialog must adopt its parent state's palette (no flicker).
+3. Owner resolution: a fresh soldier's gift target list must show the
    OTHER player (bug: client saw their own name first, click was a no-op).
 
 Run:  python tools/coop_test/test_bug_fixes.py
@@ -34,12 +34,12 @@ def test_bug3_owner_resolution(host, client):
     hbase = own_base(host)
     cbase = own_base(client)
 
-    r = client.ok({"cmd": "transfer_targets", "name": cbase["soldiers"][0]["name"]})
+    r = client.ok({"cmd": "gift_targets", "name": cbase["soldiers"][0]["name"]})
     assert r["currentOwner"] == 1, f"client's fresh soldier should resolve to owner 1, got {r['currentOwner']}"
     assert [t["id"] for t in r["targets"]] == [0], f"client targets wrong: {r['targets']}"
     assert r["targets"][0]["name"] == "HostPlayer", f"client should see host's name, got {r['targets'][0]['name']}"
 
-    r = host.ok({"cmd": "transfer_targets", "name": hbase["soldiers"][0]["name"]})
+    r = host.ok({"cmd": "gift_targets", "name": hbase["soldiers"][0]["name"]})
     assert r["currentOwner"] == 0, f"host's fresh soldier should resolve to owner 0, got {r['currentOwner']}"
     assert [t["id"] for t in r["targets"]] == [1], f"host targets wrong: {r['targets']}"
     assert r["targets"][0]["name"] == "ClientPlayer", f"host should see client's name, got {r['targets'][0]['name']}"
@@ -50,12 +50,12 @@ def test_bug2_palette(host):
     hbase = own_base(host)
     host.ok({"cmd": "open_soldiers", "base": hbase["name"]})
     host.wait_for("soldiers screen", lambda: any("SoldiersState" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
-    host.ok({"cmd": "open_transfer_dialog", "name": hbase["soldiers"][0]["name"]})
-    host.wait_for("dialog", lambda: any("TransferSoldierMenu" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
+    host.ok({"cmd": "open_gift_dialog", "name": hbase["soldiers"][0]["name"]})
+    host.wait_for("dialog", lambda: any("GiftSoldierMenu" in s for s in host.cmd({"cmd": "get_state"})["states"]) or None)
 
     pals = host.ok({"cmd": "get_palettes"})["states"]
     parent = next(e for e in pals if "SoldiersState" in e["state"])
-    dialog = next(e for e in pals if "TransferSoldierMenu" in e["state"])
+    dialog = next(e for e in pals if "GiftSoldierMenu" in e["state"])
     assert dialog["colors"] == parent["colors"], "dialog palette differs from parent (flicker)"
 
     host.ok({"cmd": "cancel_dialog"})
@@ -72,10 +72,10 @@ def test_bug1a_list_open(host, client):
     client.ok({"cmd": "open_soldiers", "base": cbase["name"]})
     client.wait_for("client list open", lambda: any("SoldiersState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None)
 
-    host.ok({"cmd": "transfer", "name": soldier, "owner": 1})
+    host.ok({"cmd": "gift", "name": soldier, "owner": 1})
 
     # notification must pop on the receiver
-    client.wait_for("transfer notice", lambda: any("TransferNoticeState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None, timeout=30)
+    client.wait_for("gift notice", lambda: any("GiftNoticeState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None, timeout=30)
     client.ok({"cmd": "dismiss_notice"})
     client.ok({"cmd": "soldiers_ok"})
 
@@ -87,8 +87,8 @@ def test_bug1a_list_open(host, client):
                     return s
         return None
 
-    client.wait_for("soldier survived list-open transfer", present, timeout=30)
-    print(f"PASS bug1a: '{soldier}' survived transfer with client's own list open (+notice shown)")
+    client.wait_for("soldier survived list-open gift", present, timeout=30)
+    print(f"PASS bug1a: '{soldier}' survived gift with client's own list open (+notice shown)")
 
 
 def test_bug1b_mirror_open(host, client):
@@ -99,10 +99,10 @@ def test_bug1b_mirror_open(host, client):
     client.ok({"cmd": "visit_coop_base", "base": hbase["name"]})
     client.wait_for("inside peer base", lambda: client.cmd({"cmd": "get_coop"}).get("insideCoopBase") or None, timeout=60)
 
-    host.ok({"cmd": "transfer", "name": soldier, "owner": 1})
+    host.ok({"cmd": "gift", "name": soldier, "owner": 1})
 
     # notice pops immediately, and the visited base shows the soldier NOW
-    client.wait_for("transfer notice while visiting", lambda: any("TransferNoticeState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None, timeout=30)
+    client.wait_for("gift notice while visiting", lambda: any("GiftNoticeState" in s for s in client.cmd({"cmd": "get_state"})["states"]) or None, timeout=30)
 
     def visible_in_visited_world():
         r = client.cmd({"cmd": "get_soldiers"})

--- a/tools/coop_test/test_coop_base_equip_visibility.py
+++ b/tools/coop_test/test_coop_base_equip_visibility.py
@@ -1,0 +1,155 @@
+"""Autonomous regression test for issue #33:
+
+  "Units at a friend's base can see equipment that is assigned to friend's
+   soldiers (unavailable, but visible)."
+
+Background: in OpenXcom a soldier's equipment-layout does NOT decrement base
+storage - the physical items always live in storage and the layout is just a
+re-equip blueprint. So the base-inventory "ground" pane (drawn from storage
+minus what the *deployed* soldiers re-take via their layouts) leaks items
+whenever a soldier that reserved items is NOT deployed:
+
+  Cases 1 & 2 (visited base): visiting a peer's co-op base clears the peer's
+    own soldiers but keeps their storage, so their reserved items show as free.
+    Fixed in CoopState (global_state 55) by subtracting departing soldiers'
+    layout items from the visited base's storage.
+
+  Cases 3 & 4 (own base): a co-op "guest" soldier stationed at your base is
+    stripped from your editable roster (SoldiersState ctor), so it is not
+    deployed and its reserved items leak onto your own ground pane. Fixed in
+    SoldiersState::btnInventoryClick by pulling guests' reserved items out of
+    storage while runInventory builds the ground (then restoring them).
+
+The test reserves an item on every soldier of both bases (via give_layout, which
+mirrors equipping: writes a layout, leaves storage untouched) and then checks
+all four visibility directions.
+
+Run:  python tools/coop_test/test_coop_base_equip_visibility.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+# A real soldier-inventory item present in the fresh starting base in a quantity
+# (8) that matches the fresh soldier count, so every soldier can reserve one.
+RESERVE_ITEM = "STR_PISTOL_CLIP"
+
+
+def _has_state(gc, name):
+    return any(name in s for s in gc.cmd({"cmd": "get_state"})["states"])
+
+
+def own_base(gc):
+    s = gc.ok({"cmd": "get_soldiers"})
+    return next(b for b in s["bases"]
+               if not b["coopBaseFlag"] and not b["coopIcon"] and b["soldiers"])
+
+
+def reserve_all(gc):
+    """Give every soldier at the local own base a layout entry for RESERVE_ITEM
+    (capped at the item stock so reserved never exceeds storage)."""
+    b = own_base(gc)
+    stock = gc.ok({"cmd": "base_report"})["storage"].get(RESERVE_ITEM, 0)
+    count = min(len(b["soldiers"]), stock)
+    assert count > 0, f"base has no {RESERVE_ITEM} to reserve"
+    g = gc.ok({"cmd": "give_layout", "item": RESERVE_ITEM, "count": count})
+    assert g.get("given") == count, f"give_layout gave {g.get('given')} != {count}"
+    return b, count
+
+
+def open_base_inventory_ground(gc, base_name):
+    """Open the base inventory (right-click-equip) for base_name and return the
+    ground pane's item tally."""
+    gc.ok({"cmd": "open_soldiers", "base": base_name})
+    gc.wait_for("soldiers screen", lambda: _has_state(gc, "SoldiersState") or None, timeout=30)
+    r = gc.ok({"cmd": "soldiers_inventory"})
+    assert r.get("opened"), f"base inventory did not open: {r}"
+    gc.wait_for("base inventory open", lambda: _has_state(gc, "InventoryState") or None, timeout=30)
+    return gc.ok({"cmd": "inventory_ground"})
+
+
+# -------------------- cases 1 & 2: the visited base --------------------
+
+def assert_visited_no_leak(owner_report, visited_report, label):
+    storage = owner_report["storage"]
+    reserved = owner_report["reserved"]
+    visited = visited_report["storage"]
+    assert reserved, f"{label}: precondition failed - owner reserved nothing"
+    leaks = {}
+    for t, rc in reserved.items():
+        assert rc <= storage.get(t, 0), f"{label}: reserved {rc} > stock {storage.get(t,0)} of {t}"
+        free = storage.get(t, 0) - rc
+        seen = visited.get(t, 0)
+        if seen > free:
+            leaks[t] = {"seen": seen, "free": free, "reserved": rc, "full": storage.get(t, 0)}
+    assert not leaks, f"{label}: LEAK - visited base exposes owner-reserved items: {leaks}"
+    print(f"PASS {label}: reserved items hidden from the visited base "
+          f"(visited pool {RESERVE_ITEM} = {visited.get(RESERVE_ITEM, 0)})")
+
+
+def run_visited_case(visitor, owner, owner_base_name, label):
+    owner_report = owner.ok({"cmd": "base_report"})
+    visitor.ok({"cmd": "visit_coop_base", "base": owner_base_name})
+    visitor.wait_for("inside peer base",
+                     lambda: visitor.cmd({"cmd": "get_coop"}).get("insideCoopBase") or None, timeout=60)
+    visited_report = visitor.ok({"cmd": "base_report", "coop": True})
+    assert_visited_no_leak(owner_report, visited_report, label)
+    visitor.ok({"cmd": "leave_base"})
+    visitor.wait_for("back in own world",
+                     lambda: (not visitor.cmd({"cmd": "get_coop"}).get("insideCoopBase")) or None, timeout=60)
+
+
+# -------------------- cases 3 & 4: the own base --------------------
+
+def run_ownbase_case(owner, base, label):
+    """Turn one of the owner's soldiers into a stripped co-op "guest" (coopBase
+    != -1) and confirm its reserved item no longer leaks onto the owner's own
+    inventory ground."""
+    guest = base["soldiers"][0]["name"]
+    owner.ok({"cmd": "set_coop_base", "name": guest, "value": 999})
+    rep = owner.ok({"cmd": "base_report"})
+    stripped = [s["name"] for s in rep["soldiers"] if s["coopBase"] != -1]
+    assert guest in stripped, f"{label}: '{guest}' was not stripped (coopBase not set)"
+
+    g = open_base_inventory_ground(owner, base["name"])
+    seen = g["items"].get(RESERVE_ITEM, 0)
+    assert seen == 0, (f"{label}: LEAK - owner sees {seen} {RESERVE_ITEM} reserved by a "
+                       f"stripped guest soldier on its own ground pane")
+    print(f"PASS {label}: stripped guest's reserved {RESERVE_ITEM} hidden from owner's own ground")
+
+
+def main():
+    host = GameClient("host", 47811, make_user_dir("host-user"))
+    client = GameClient("client", 47812, make_user_dir("client-user"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+        session.new_campaign(host, client)
+        print("fresh coop session established")
+
+        hbase, _ = reserve_all(host)
+        cbase, _ = reserve_all(client)
+        print(f"reserved {RESERVE_ITEM} on all soldiers of '{hbase['name']}' and '{cbase['name']}'")
+
+        # Case 1: host visits the client's base -> must not see client-equipped items.
+        run_visited_case(host, client, cbase["name"], "case1 host@client-base")
+        # Case 2: client visits the host's base -> must not see host-equipped items.
+        run_visited_case(client, host, hbase["name"], "case2 client@host-base")
+
+        # Case 3: client's own base holds a stripped guest -> client must not see
+        #         that guest's reserved items on its own ground pane.
+        run_ownbase_case(client, cbase, "case3 client-own-base guest")
+        # Case 4: host's own base holds a stripped guest -> same, other direction.
+        run_ownbase_case(host, hbase, "case4 host-own-base guest")
+
+        print("TEST PASSED")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_coop_transfer_equipment_counts.py
+++ b/tools/coop_test/test_coop_transfer_equipment_counts.py
@@ -1,0 +1,118 @@
+"""Validates that a soldier's equipped items move with it when it is vanilla-
+transferred to a co-op base, driven by the "Alternate craft equipment
+management" option:
+
+  ON  - the gear's item counts move AND arrive IMMEDIATELY (a 0-hour transfer,
+        matching the instant soldier move): the sending base's stored count
+        drops, the receiving base's stored count rises by the same amount, with
+        no pending timed transfer and no in-game time elapsing.
+  OFF - nothing moves.
+
+Immediacy is proven definitively: both instances sit paused after
+new_campaign, so a travel-timed transfer could NEVER arrive (its clock never
+moves). The receiving base's stored count going up while the in-game clock is
+unchanged can only mean the items landed instantly.
+
+Several distinct items are equipped (a rocket in one hand, a pistol in the
+other) so multi-item transfer is covered too.
+
+Only a base-resident (non-craft) soldier is individually transferable and a
+fresh base has one, so each mode runs in its own fresh session.
+
+Run:  python tools/coop_test/test_coop_transfer_equipment_counts.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+import geo
+
+# item -> inventory slot; both are present in a fresh starting base.
+GEAR = {"STR_SMALL_ROCKET": "left", "STR_PISTOL": "right"}
+OPT = "oxceAlternateCraftEquipmentManagement"
+
+
+def own_base(gc):
+    s = gc.ok({"cmd": "get_soldiers"})
+    return next(b for b in s["bases"]
+               if not b["coopBaseFlag"] and not b["coopIcon"] and b["soldiers"])
+
+
+def stored(gc, base_name, item):
+    return gc.ok({"cmd": "base_report", "base": base_name})["storage"].get(item, 0)
+
+
+def incoming(gc, base_name, item):
+    return gc.ok({"cmd": "incoming_transfers", "base": base_name})["items"].get(item, 0)
+
+
+def run(alt_on):
+    host = GameClient("host", 47811, make_user_dir("host-user"))
+    client = GameClient("client", 47812, make_user_dir("client-user"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+        session.new_campaign(host, client)
+
+        hb = own_base(host); cb = own_base(client)
+        host.ok({"cmd": "set_option", "name": OPT, "value": alt_on})
+        client.ok({"cmd": "set_option", "name": OPT, "value": alt_on})
+
+        # the lone base-resident soldier, uniquely named + several equipped items
+        soldier = next(s for s in hb["soldiers"] if not s.get("craft"))["name"]
+        host.ok({"cmd": "rename_soldier", "name": soldier, "newName": "Zzz Xfer"})
+        for item, slot in GEAR.items():
+            host.ok({"cmd": "give_layout", "item": item, "slot": slot, "name": "Zzz", "count": 1})
+
+        send0 = {i: stored(host, hb["name"], i) for i in GEAR}
+        recv0 = {i: stored(client, cb["name"], i) for i in GEAR}
+        for i, q in send0.items():
+            assert q >= 1, f"sending base needs a {i} to reason about (has {q})"
+        clock0 = geo.game_minutes(client)
+
+        host.ok({"cmd": "transfer_to_coop_base", "name": "Zzz", "toBase": cb["name"]})
+
+        if alt_on:
+            # every reserved item leaves the sender immediately...
+            for i in GEAR:
+                assert stored(host, hb["name"], i) == send0[i] - 1, \
+                    f"ON: sender {i} {send0[i]} -> {stored(host, hb['name'], i)}, expected -1"
+            # ...and lands in the receiver's STORAGE immediately (no time advance).
+            client.wait_for(
+                "all gear stored at receiving base immediately",
+                lambda: all(stored(client, cb["name"], i) == recv0[i] + 1 for i in GEAR) or None,
+                timeout=20)
+            clock1 = geo.game_minutes(client)
+            for i in GEAR:
+                assert incoming(client, cb["name"], i) == 0, f"ON: {i} should land in storage, not queue"
+                assert (stored(host, hb["name"], i) + stored(client, cb["name"], i)) \
+                    == (send0[i] + recv0[i]), f"ON: world {i} total changed"
+            # definitive immediacy: the receiver's clock never advanced.
+            assert clock1 == clock0, \
+                f"ON: gear arrived only after in-game time passed ({clock0} -> {clock1}); not immediate"
+            print(f"PASS ON: {list(GEAR)} each moved sender -1 / receiver +1, "
+                  f"immediately (clock frozen at {clock0}), world conserved")
+        else:
+            for _ in range(4):
+                host.cmd({"cmd": "ping"}); client.cmd({"cmd": "ping"}); time.sleep(1)
+            for i in GEAR:
+                assert stored(host, hb["name"], i) == send0[i], f"OFF: sender {i} changed"
+                assert stored(client, cb["name"], i) == recv0[i], f"OFF: receiver {i} changed"
+                assert incoming(client, cb["name"], i) == 0, f"OFF: receiver got {i} incoming"
+            print(f"PASS OFF: nothing moved (sender & receiver unchanged for {list(GEAR)})")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+def main():
+    run(alt_on=True)
+    run(alt_on=False)
+    print("TEST PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_coop_transfer_equipment_option.py
+++ b/tools/coop_test/test_coop_transfer_equipment_option.py
@@ -1,0 +1,89 @@
+"""Regression test: the "Alternate craft equipment management" option
+(Options::oxceAlternateCraftEquipmentManagement) drives whether a soldier's
+equipment travels with it when it is vanilla-transferred to a co-op base.
+
+  OFF (default): a soldier's gear is not carried between bases. The transferred
+    soldier is stripped - it arrives at the peer base with an empty layout.
+  ON: the equipment layout travels with the soldier; it stays equipped at the
+    peer base.
+
+This test only checks the guest's *layout* at the peer base (stripped vs kept).
+The matching item-count movement (ON: sender -N / receiver +N) is covered by
+test_coop_transfer_equipment_counts.py.
+
+Only a base-resident (non-craft) soldier is individually transferable, and a
+fresh base has exactly one, so each mode runs in its own fresh session.
+
+Run:  python tools/coop_test/test_coop_transfer_equipment_option.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+ROCKET = "STR_SMALL_ROCKET"
+OPT = "oxceAlternateCraftEquipmentManagement"
+
+
+def own_base(gc):
+    s = gc.ok({"cmd": "get_soldiers"})
+    return next(b for b in s["bases"]
+               if not b["coopBaseFlag"] and not b["coopIcon"] and b["soldiers"])
+
+
+def run_mode(alt_on, label):
+    host = GameClient("host", 47811, make_user_dir("host-user"))
+    client = GameClient("client", 47812, make_user_dir("client-user"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+        session.new_campaign(host, client)
+
+        hb = own_base(host); cb = own_base(client)
+
+        # the lone base-resident soldier, uniquely named + a rocket in the off-hand
+        soldier = next(s for s in hb["soldiers"] if not s.get("craft"))["name"]
+        host.ok({"cmd": "rename_soldier", "name": soldier, "newName": "Zzz Xfer"})
+        host.ok({"cmd": "give_layout", "item": ROCKET, "slot": "left", "name": "Zzz", "count": 1})
+
+        # both machines share the option value
+        host.ok({"cmd": "set_option", "name": OPT, "value": alt_on})
+        client.ok({"cmd": "set_option", "name": OPT, "value": alt_on})
+
+        r = host.ok({"cmd": "transfer_to_coop_base", "name": "Zzz", "toBase": cb["name"]})
+        assert r.get("transferred"), f"{label}: transfer failed: {r}"
+
+        host.ok({"cmd": "visit_coop_base", "base": cb["name"]})
+        host.wait_for("inside peer base",
+                      lambda: host.cmd({"cmd": "get_coop"}).get("insideCoopBase") or None, timeout=60)
+        rep = host.ok({"cmd": "base_report", "coop": True})
+        guest = next((s for s in rep["soldiers"] if "Zzz" in s["name"]), None)
+        assert guest is not None, f"{label}: transferred soldier not at the visited base"
+        layout = guest["layout"]
+        print(f"{label}: visited guest '{guest['name']}' layout={layout}")
+
+        host.ok({"cmd": "leave_base"})
+        host.wait_for("back home",
+                      lambda: (not host.cmd({"cmd": "get_coop"}).get("insideCoopBase")) or None, timeout=60)
+        return layout
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+def main():
+    off_layout = run_mode(False, "OFF")
+    assert off_layout == [], f"OFF: expected the transferred soldier stripped (empty layout), got {off_layout}"
+    print("PASS OFF: soldier stripped on transfer (empty layout at peer base)")
+
+    on_layout = run_mode(True, "ON")
+    assert ROCKET in on_layout, f"ON: expected the transferred soldier to keep its {ROCKET}, got {on_layout}"
+    print("PASS ON: soldier kept its loadout on transfer (equipped at peer base)")
+
+    print("TEST PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_coop_transferred_equipment.py
+++ b/tools/coop_test/test_coop_transferred_equipment.py
@@ -1,0 +1,131 @@
+"""Regression test for the "extra rocket after transferring an equipped soldier"
+report (issue investigation).
+
+Scenario: the host equips a base soldier with a rocket (persistent layout),
+then does a *vanilla base transfer* (NOT a gift/ownership change) of that
+soldier to the client's base. Both players then look at the soldier equip
+screen for the client's base.
+
+The concern raised was that a soldier's equipment might be *duplicated* by the
+transfer. This test locks in the conservation invariant that proves it is not:
+
+  1. The total number of the item across the whole co-op world (host base
+     storage + client base storage) is unchanged by the transfer.
+  2. In the equip screen at the client's base, the total number of rocket
+     *instances* actually present (ground + carried + loaded) never exceeds the
+     client base's real storage - and is the same whether the host (visiting)
+     or the client (at home) opens it.
+
+Run:  python tools/coop_test/test_coop_transferred_equipment.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+ROCKET = "STR_SMALL_ROCKET"
+
+
+def _has_state(gc, n):
+    return any(n in s for s in gc.cmd({"cmd": "get_state"})["states"])
+
+
+def own_base(gc):
+    s = gc.ok({"cmd": "get_soldiers"})
+    return next(b for b in s["bases"]
+               if not b["coopBaseFlag"] and not b["coopIcon"] and b["soldiers"])
+
+
+def storage_rockets(gc, base_name=None, coop=False):
+    req = {"cmd": "base_report"}
+    if coop:
+        req["coop"] = True
+    elif base_name:
+        req["base"] = base_name
+    return gc.ok(req)["storage"].get(ROCKET, 0)
+
+
+def equip_rocket_instances(gc, base_name):
+    """Open the base equip screen and return (all_instances, ground, carried, units)."""
+    gc.ok({"cmd": "open_soldiers", "base": base_name})
+    gc.wait_for("soldiers", lambda: _has_state(gc, "SoldiersState") or None, timeout=30)
+    r = gc.ok({"cmd": "soldiers_inventory"})
+    assert r.get("opened"), f"equip screen did not open: {r}"
+    gc.wait_for("inventory", lambda: _has_state(gc, "InventoryState") or None, timeout=30)
+    g = gc.ok({"cmd": "inventory_ground"})
+    # close back out cleanly
+    gc.ok({"cmd": "battle_inventory", "action": "ok"})
+    gc.wait_for("closed", lambda: (not _has_state(gc, "InventoryState")) or None, timeout=30)
+    gc.ok({"cmd": "soldiers_ok"})
+    return (g["all"].get(ROCKET, 0), g["items"].get(ROCKET, 0),
+            g["carried"].get(ROCKET, 0), g["units"])
+
+
+def main():
+    host = GameClient("host", 47811, make_user_dir("host-user"))
+    client = GameClient("client", 47812, make_user_dir("client-user"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+        session.new_campaign(host, client)
+        print("fresh coop session established")
+
+        hb = own_base(host); cb = own_base(client)
+        world_rockets_before = storage_rockets(host, hb["name"]) + storage_rockets(client, cb["name"])
+        client_stock = storage_rockets(client, cb["name"])
+        print(f"world rockets before={world_rockets_before}, client base stock={client_stock}")
+        assert client_stock > 0, "client base has no rockets to reason about"
+
+        # host equips a base-resident soldier with a rocket in the off-hand
+        soldier = next(s for s in hb["soldiers"] if not s.get("craft"))["name"]
+        host.ok({"cmd": "give_layout", "item": ROCKET, "slot": "left", "name": soldier, "count": 1})
+        print(f"equipped host soldier '{soldier}' with a {ROCKET} (off-hand)")
+
+        # vanilla base transfer of that soldier to the client's base
+        tr = host.ok({"cmd": "transfer_to_coop_base", "name": soldier, "toBase": cb["name"]})
+        assert tr.get("transferred"), f"transfer failed: {tr}"
+
+        def client_sees():
+            s = client.cmd({"cmd": "get_soldiers"})
+            return any(x["name"] == soldier for b in s.get("bases", []) for x in b["soldiers"]) or None
+        client.wait_for("client sees transferred soldier", client_sees, timeout=30)
+
+        # (1) no item created anywhere in the co-op world
+        world_rockets_after = storage_rockets(host, hb["name"]) + storage_rockets(client, cb["name"])
+        assert world_rockets_after == world_rockets_before, (
+            f"item DUPLICATION: world rockets {world_rockets_before} -> {world_rockets_after}")
+        print(f"PASS no-world-duplication: world rockets still {world_rockets_after}")
+
+        # (2) host visits the client base (client idle) and opens the equip screen
+        host.ok({"cmd": "visit_coop_base", "base": cb["name"]})
+        host.wait_for("host inside peer base",
+                      lambda: host.cmd({"cmd": "get_coop"}).get("insideCoopBase") or None, timeout=60)
+        host_all, host_gnd, host_car, host_units = equip_rocket_instances(host, cb["name"])
+        host.ok({"cmd": "leave_base"})
+        host.wait_for("host back home",
+                      lambda: (not host.cmd({"cmd": "get_coop"}).get("insideCoopBase")) or None, timeout=60)
+
+        # client opens the equip screen for its own base (host idle)
+        cli_all, cli_gnd, cli_car, cli_units = equip_rocket_instances(client, cb["name"])
+
+        print(f"HOST visited: rocket_instances={host_all} (ground={host_gnd} carried={host_car} units={host_units})")
+        print(f"CLIENT home : rocket_instances={cli_all} (ground={cli_gnd} carried={cli_car} units={cli_units})")
+
+        assert host_all <= client_stock, (
+            f"host equip screen shows {host_all} rocket instances > client stock {client_stock} (phantom items)")
+        assert cli_all <= client_stock, (
+            f"client equip screen shows {cli_all} rocket instances > client stock {client_stock}")
+        assert host_all == cli_all, (
+            f"host and client disagree on total rocket instances at the client base: "
+            f"host={host_all} client={cli_all}")
+        print(f"PASS equip-view-conservation: both see {host_all} rocket instances (== stock {client_stock})")
+        print("TEST PASSED")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coop_test/test_gift_fresh.py
+++ b/tools/coop_test/test_gift_fresh.py
@@ -1,7 +1,7 @@
-"""Autonomous test: brand-new hosted campaign, connect a client, transfer the
+"""Autonomous test: brand-new hosted campaign, connect a client, gift the
 first host soldier, verify the client sees them at the host's base.
 
-Run:  python tools/coop_test/test_transfer_fresh.py
+Run:  python tools/coop_test/test_gift_fresh.py
 """
 
 import os
@@ -23,14 +23,14 @@ def main():
         session.new_campaign(host, client)
         print("fresh coop session established")
 
-        # --- pick host's first soldier, transfer, verify ---
+        # --- pick host's first soldier, gift, verify ---
         hs = host.ok({"cmd": "get_soldiers"})
         hbase = next(b for b in hs["bases"] if not b["coopBaseFlag"] and b["soldiers"])
         soldier = hbase["soldiers"][0]
         host_base_id = hbase["coopBaseId"]
-        print(f"transferring {soldier['name']} from '{hbase['name']}' (coopBaseId={host_base_id})")
+        print(f"gifting {soldier['name']} from '{hbase['name']}' (coopBaseId={host_base_id})")
 
-        host.ok({"cmd": "transfer", "name": soldier["name"], "owner": 1})
+        host.ok({"cmd": "gift", "name": soldier["name"], "owner": 1})
 
         def client_sees():
             r = client.cmd({"cmd": "get_mirror_soldiers", "coopBaseId": host_base_id})

--- a/tools/coop_test/test_gift_rollback.py
+++ b/tools/coop_test/test_gift_rollback.py
@@ -1,10 +1,10 @@
-"""Autonomous test: host save = single source of truth for soldier transfers.
+"""Autonomous test: host save = single source of truth for soldier gifts.
 
 Exact user repro:
   1. new game, host + client connected
-  2. host transfers unit A to client
+  2. host gifts unit A to client
   3. host saves game
-  4. host transfers unit B to client
+  4. host gifts unit B to client
   5. host abandons (in-session: statics survive, like returning to main menu)
   6. host loads the save, client re-fetches its world from the host
   7. EXPECTED: host has B (not A), client has A (not B), no bogus notices
@@ -12,7 +12,7 @@ Exact user repro:
 Also runs the reverse direction (client gives, host's save still authority)
 and the stacked-notice color check.
 
-Run:  python tools/coop_test/test_transfer_rollback.py
+Run:  python tools/coop_test/test_gift_rollback.py
 """
 
 import os
@@ -40,7 +40,7 @@ def dismiss_all_notices(gc):
 
 
 def no_notices(gc):
-    return not any("TransferNoticeState" in s for s in gc.cmd({"cmd": "get_state"})["states"])
+    return not any("GiftNoticeState" in s for s in gc.cmd({"cmd": "get_state"})["states"])
 
 
 def wait_blob_fresh(host, client):
@@ -53,8 +53,8 @@ def wait_blob_fresh(host, client):
     time.sleep(3)  # existence check can't tell a fresh push from an old one
 
 
-def transfer_and_wait(giver, receiver, name, receiver_owner_id):
-    giver.ok({"cmd": "transfer", "name": name, "owner": receiver_owner_id})
+def gift_and_wait(giver, receiver, name, receiver_owner_id):
+    giver.ok({"cmd": "gift", "name": name, "owner": receiver_owner_id})
     receiver.wait_for(f"{name} arrives",
                       lambda: (soldier_count(receiver, name, owner=receiver_owner_id) == 1) or None, timeout=30)
     dismiss_all_notices(receiver)
@@ -67,15 +67,15 @@ def run_repro(host, client, giver, receiver, receiver_owner_id, tag):
     giver.ok({"cmd": "rename_soldier", "name": roster[0]["name"], "newName": unit_a})
     giver.ok({"cmd": "rename_soldier", "name": roster[1]["name"], "newName": unit_b})
 
-    # 2. transfer A
-    transfer_and_wait(giver, receiver, unit_a, receiver_owner_id)
+    # 2. gift A
+    gift_and_wait(giver, receiver, unit_a, receiver_owner_id)
     wait_blob_fresh(host, client)
 
     # 3. HOST saves (the authority snapshot: A traded, B not)
     host.ok({"cmd": "save_game", "file": f"authority_{tag}.sav"})
 
-    # 4. transfer B
-    transfer_and_wait(giver, receiver, unit_b, receiver_owner_id)
+    # 4. gift B
+    gift_and_wait(giver, receiver, unit_b, receiver_owner_id)
     wait_blob_fresh(host, client)
 
     # 5+6. host "abandons" and loads the save; client re-fetches its world


### PR DESCRIPTION
## Summary

Three related co-op changes:

1. Fix issue #33.
2. Rename the "gift a soldier" feature off the overloaded "transfer" wording.
3. Implement feature #34.

## 1. Issue #33: foreign-base equipment visibility

Root cause: an equipment layout is a re-equip template and never decrements base storage, so the base-inventory ground pane leaks items whenever a soldier that reserved items is not deployed. Two places drop such soldiers but keep their storage:

- Visiting a peer co-op base: the peer's own soldiers are cleared but their storage is kept, so their reserved items show as free.
- Your own base holding a co-op "guest" soldier: the guest is stripped from your editable roster, so its reserved items leak onto your own ground pane.

Fixes:

- CoopState visited-base reconstruction subtracts the departing peer soldiers' layout items (weapon plus loaded ammo) from the visited base's storage.
- SoldiersState::btnInventoryClick pulls a stripped guest's reserved items out of storage while runInventory builds the ground, then restores them.

Both are cosmetic. Real base storage counts, craft equipment, and world-wide item totals are unchanged (base-mode runInventory never mutates storage; the visited base is a throwaway view). All four host/client directions are covered.

## 2. Gift rename

The ownership-change action ("give unit to teammate") was named with "transfer", colliding with the vanilla base-to-base transfer. Renamed the ownership feature to "gift":

- GiftSoldierMenu, GiftNoticeState, connectionTCP::giftSoldier(), the "giftSoldier" wire packet, the pending/gifted member vars, and the harness commands gift, gift_targets, open_gift_dialog.
- Kept as "transfer" (correctly): vanilla TransferItemsState, getTransfers, TRANSFER_SOLDIER, syncTrade, the "transfer" packet, and the world-data streaming comments.
- Kept as-is: the ownership accessors (getOwnerPlayerId/setOwnerPlayerId, resolveOwnerId) and the giveUnit keybind and "giveUnit" packet (a persisted option key, and already "give", not "transfer").

Wire note: the "transferSoldier" packet is now "giftSoldier", so both peers must run the matched build. Co-op already enforces a matching mod version.

## 3. Issue #34: Transfer equipment option

Vanilla soldier transfer to a co-op base now honors Options::oxceAlternateCraftEquipmentManagement, the same knob the base repository uses:

- OFF (the option default): a soldier's gear does not travel between bases, so its layout is stripped on transfer and it arrives at the peer base empty. The items stay in the origin base.
- ON: the equipped items move with the soldier to the receiving base, and they arrive immediately (a 0-hour transfer, matching the instant soldier move). syncTrade lands 0-hour item transfers straight into storage instead of queuing a timed transfer.

Behavior change to note: because the option defaults OFF, the default co-op transfer behavior is now "strip". Previously the layout was kept, which is what produced the reported extra item at the peer base.

## Tests

New autonomous two-client coop-harness tests:

- test_coop_base_equip_visibility.py: issue #33 across all four host/client directions.
- test_coop_transferred_equipment.py: transferring an equipped soldier does not duplicate items (world total and per-view instance counts conserved).
- test_coop_transfer_equipment_option.py: OFF strips the guest layout, ON keeps it.
- test_coop_transfer_equipment_counts.py: ON moves the item counts (sender minus N, receiver plus N) and they arrive immediately, proven by the receiver's stored count rising while the in-game clock is frozen; OFF moves nothing.

Existing gift and coop tests updated for the rename and passing.

Supporting TestServer harness commands added: base_report, soldiers_inventory, inventory_ground, give_layout, set_coop_base, transfer_to_coop_base, incoming_transfers, and set_option for oxceAlternateCraftEquipmentManagement, plus a small TransferItemsState::transferSoldierNow test hook.