### PR TITLE
fix(coop): guard null inventory slot when unloading weapon at base (#29)

### DIFF
--- a/src/Battlescape/Inventory.cpp
+++ b/src/Battlescape/Inventory.cpp
@@ -553,7 +553,11 @@ void Inventory::moveItem(BattleItem* item, const RuleInventory* slot, int x, int
 		if (item && slot && _game->getCoopMod()->coopInventory == false && _game->getCoopMod()->getCoopCampaign() == true)
 		{
 
-			if (item->getSlot()->getType() == INV_GROUND && slot->getType() == INV_GROUND)
+			// item->getSlot() can be null here: ammo just unloaded from a weapon has
+			// its inventory slot cleared (setAmmoForSlot -> setSlot(nullptr)) before
+			// being handed to moveItem. Treat "no slot" as "not a ground->ground move"
+			// so we don't deref null (issue #29: unload crash, 0xC0000005).
+			if (item->getSlot() && item->getSlot()->getType() == INV_GROUND && slot->getType() == INV_GROUND)
 			{
 				send = false;
 			}

--- a/src/Battlescape/InventoryState.h
+++ b/src/Battlescape/InventoryState.h
@@ -164,6 +164,10 @@ public:
 	// coop
 	void moveCoopItemsToGround(Craft* craft, BattleUnit *unit);
 
+	// test-harness only: expose the inventory view so the TestServer can drive
+	// unload() the same way btnUnloadClick does (see issue #29 unload crash repro).
+	Inventory *getInventoryForTest() const { return _inv; }
+
 private:
 	/// Update the visibility and icons for the template buttons.
 	void updateTemplateButtons(bool isVisible);

--- a/src/CoopMod/TestServer.cpp
+++ b/src/CoopMod/TestServer.cpp
@@ -42,6 +42,7 @@
 #include "../Battlescape/BattlescapeGame.h"
 #include "../Battlescape/BriefingState.h"
 #include "../Battlescape/InventoryState.h"
+#include "../Battlescape/Inventory.h"
 #include "../Battlescape/NextTurnState.h"
 #include "../Battlescape/AbortMissionState.h"
 #include "../Battlescape/DebriefingState.h"
@@ -1503,6 +1504,104 @@ std::string TestServer::execute(const std::string& line)
 				resp["all"] = all;
 				resp["allTotal"] = allTotal;
 				resp["ok"] = true;
+			}
+		}
+		else if (cmd == "inventory_unload")
+		{
+			// Reproduce issue #29: unloading a loaded weapon from the base soldier
+			// equip screen. Drives Inventory::unload() exactly like btnUnloadClick,
+			// which is where the co-op moveItem() path deref'd the just-unloaded
+			// ammo's (null) inventory slot and crashed (0xC0000005).
+			//
+			// Requires an open base inventory (call soldiers_inventory first). If the
+			// currently selected soldier has no loaded firearm, one is built and
+			// loaded so the unload path is always exercised.
+			InventoryState* inv = findState<InventoryState>(_game);
+			SavedGame* sg = _game->getSavedGame();
+			SavedBattleGame* bg = sg ? sg->getSavedBattle() : nullptr;
+			if (!inv || !bg)
+			{
+				resp["error"] = "no InventoryState/battle active (call soldiers_inventory first)";
+			}
+			else
+			{
+				Inventory* inventory = inv->getInventoryForTest();
+				BattleUnit* unit = inventory ? inventory->getSelectedUnit() : nullptr;
+				Tile* ground = bg->getTile(0);
+				if (!unit)
+				{
+					resp["error"] = "no selected unit in inventory";
+				}
+				else if (!ground)
+				{
+					resp["error"] = "no ground tile in inventory battle";
+				}
+				else
+				{
+					// Deterministic setup: clear the selected soldier's hands to the
+					// ground so unload(false) always has the free hand it needs and
+					// actually reaches the (previously crashing) moveItem() path -
+					// independent of any state a prior unload left on this soldier.
+					RuleInventory* groundRule = _game->getMod()->getInventoryGround();
+					auto* uinv = unit->getInventory();
+					for (auto it = uinv->begin(); it != uinv->end(); )
+					{
+						BattleItem* bi = *it;
+						if (bi->getSlot() && bi->getSlot()->getType() == INV_HAND)
+						{
+							it = uinv->erase(it);
+							ground->addItem(bi, groundRule);
+						}
+						else
+						{
+							++it;
+						}
+					}
+
+					// Build + load a firearm on the (now empty-handed) soldier.
+					const RuleItem* wRule = nullptr;
+					const RuleItem* aRule = nullptr;
+					for (auto& name : _game->getMod()->getItemsList())
+					{
+						const RuleItem* r = _game->getMod()->getItem(name, false);
+						if (!r || r->getBattleType() != BT_FIREARM) continue;
+						if (r->isFixed()) continue;  // skip tank/vehicle-mounted weapons - not hand-holdable
+						if (r->getInventoryWidth() == 0 || r->getInventoryHeight() == 0) continue;
+						auto* ammos = r->getPrimaryCompatibleAmmo();
+						if (ammos && !ammos->empty()) { wRule = r; aRule = ammos->front(); break; }
+					}
+					if (!wRule)
+					{
+						resp["error"] = "no firearm+ammo rule available in mod";
+					}
+					else
+					{
+						// Place the weapon straight into the (now free) right hand,
+						// bypassing addItem()'s weight/placement heuristics which can
+						// refuse an off-craft base soldier.
+						BattleItem* weapon = bg->createItemForTile(wRule, ground);
+						weapon->moveToOwner(unit);
+						weapon->setSlot(_game->getMod()->getInventoryRightHand());
+						weapon->setSlotX(0);
+						weapon->setSlotY(0);
+
+						BattleItem* ammo = bg->createItemForTile(aRule, ground);
+						ground->removeItem(ammo);
+						if (!weapon->setAmmoPreMission(ammo))
+						{
+							resp["error"] = "could not load ammo into weapon";
+						}
+						else
+						{
+							resp["weapon"] = weapon->getRules()->getType();
+							inventory->setSelectedItem(weapon);
+							// This is the call that crashed pre-fix (issue #29).
+							bool unloaded = inventory->unload(false);
+							resp["unloaded"] = unloaded;
+							resp["ok"] = true;
+						}
+					}
+				}
 			}
 		}
 		else if (cmd == "incoming_transfers")

--- a/tools/coop_test/test_unload_weapon_crash.py
+++ b/tools/coop_test/test_unload_weapon_crash.py
@@ -1,0 +1,112 @@
+"""Regression test for issue #29: "Unloading a magazine in the base crashes the
+game" (SEH 0xC0000005 access violation).
+
+Root cause: when a weapon is unloaded from the base soldier-equip screen, the
+just-removed ammo has its inventory slot cleared (BattleItem::setAmmoForSlot ->
+setSlot(nullptr)). The co-op Inventory::moveItem() broadcast path then did
+`item->getSlot()->getType()` on that ammo and dereferenced null.
+
+This test drives Inventory::unload() (the exact call btnUnloadClick makes) from
+the base equip screen via the TestServer `inventory_unload` command, in three
+co-op contexts, and asserts the game process survives each unload:
+
+  A. host unloads a weapon on one of its OWN base soldiers
+  B. client unloads a weapon on one of its OWN base soldiers
+  C. a soldier is transferred host -> client base; the client opens the equip
+     screen at that base and unloads a (freshly reloaded) weapon there.
+
+Before the fix each unload crashes the process -> the next socket command raises
+ConnectionError. After the fix the command returns {ok, unloaded:true} and the
+process is still alive.
+
+Run:  python tools/coop_test/test_unload_weapon_crash.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import GameClient, make_user_dir
+import session
+
+
+def _has_state(gc, n):
+    return any(n in s for s in gc.cmd({"cmd": "get_state"})["states"])
+
+
+def own_base(gc):
+    s = gc.ok({"cmd": "get_soldiers"})
+    return next(b for b in s["bases"]
+               if not b["coopBaseFlag"] and not b["coopIcon"] and b["soldiers"])
+
+
+def assert_alive(gc, where):
+    """The process must still be running and responsive after an unload."""
+    assert gc.proc.poll() is None, f"{gc.name}: process CRASHED during {where} (rc={gc.proc.returncode})"
+    r = gc.cmd({"cmd": "ping"})
+    assert r.get("ok") or r.get("pong") or r, f"{gc.name}: unresponsive after {where}: {r}"
+
+
+def unload_at_base(gc, base_name, where):
+    """Open the base equip screen for base_name and unload a loaded weapon.
+
+    Returns the inventory_unload response. Raises ConnectionError if the process
+    crashed (the pre-fix behaviour)."""
+    gc.ok({"cmd": "open_soldiers", "base": base_name})
+    gc.wait_for("soldiers", lambda: _has_state(gc, "SoldiersState") or None, timeout=30)
+    r = gc.ok({"cmd": "soldiers_inventory"})
+    assert r.get("opened"), f"equip screen did not open: {r}"
+    gc.wait_for("inventory", lambda: _has_state(gc, "InventoryState") or None, timeout=30)
+
+    # THE repro: drive Inventory::unload() exactly like the unload button.
+    resp = gc.cmd({"cmd": "inventory_unload"})   # raises ConnectionError on crash
+    assert_alive(gc, where)
+    assert resp.get("ok"), f"{gc.name}: inventory_unload failed at {where}: {resp}"
+    assert resp.get("unloaded"), f"{gc.name}: unload did not run at {where}: {resp}"
+    print(f"PASS {where}: unloaded {resp.get('weapon')} without crashing ({gc.name})")
+
+    # close the equip screen cleanly
+    gc.ok({"cmd": "battle_inventory", "action": "ok"})
+    gc.wait_for("closed", lambda: (not _has_state(gc, "InventoryState")) or None, timeout=30)
+    gc.ok({"cmd": "soldiers_ok"})
+    return resp
+
+
+def main():
+    host = GameClient("host", 47811, make_user_dir("host-user"))
+    client = GameClient("client", 47812, make_user_dir("client-user"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+        session.new_campaign(host, client)
+        print("fresh coop session established")
+
+        hb = own_base(host)
+        cb = own_base(client)
+
+        # A. host unloads on its own base soldier
+        unload_at_base(host, hb["name"], "A/host-own-base")
+
+        # B. client unloads on its own base soldier
+        unload_at_base(client, cb["name"], "B/client-own-base")
+
+        # C. transfer a host soldier to the client's base, then the client
+        #    unloads a reloaded weapon on a soldier at that (foreign-origin) base.
+        soldier = next(s for s in hb["soldiers"] if not s.get("craft"))["name"]
+        tr = host.ok({"cmd": "transfer_to_coop_base", "name": soldier, "toBase": cb["name"]})
+        assert tr.get("transferred"), f"transfer failed: {tr}"
+
+        def client_sees():
+            s = client.cmd({"cmd": "get_soldiers"})
+            return any(x["name"] == soldier for b in s.get("bases", []) for x in b["soldiers"]) or None
+        client.wait_for("client sees transferred soldier", client_sees, timeout=30)
+
+        unload_at_base(client, cb["name"], "C/client-transferred-base")
+
+        print("TEST PASSED")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes #29. Unloading a loaded weapon from the base soldier-equip screen crashed the game with an access violation (0xC0000005) during a co-op campaign.

## Root cause

BattleItem::setAmmoForSlot clears an ammo item's inventory slot (setSlot(nullptr)) while it is loaded inside a weapon. When the player unloads, the ammo is detached from the weapon with its slot still null and handed to Inventory::moveItem. The co-op broadcast path in moveItem did:

    if (item->getSlot()->getType() == INV_GROUND && slot->getType() == INV_GROUND)

and dereferenced the null slot, faulting with 0xC0000005.

## Fix

One-line null guard in src/Battlescape/Inventory.cpp. A null slot is treated as "not a ground-to-ground move", so the inventory-change packet is broadcast normally instead of crashing:

    if (item->getSlot() && item->getSlot()->getType() == INV_GROUND && slot->getType() == INV_GROUND)

## Test

Adds an automated regression test that drives the exact unload path the UI button uses.

- New TestServer command inventory_unload: clears the selected soldier's hands, builds and loads a firearm, then calls Inventory::unload(false), which is the same call btnUnloadClick makes.
- New test-only accessor InventoryState::getInventoryForTest().
- tools/coop_test/test_unload_weapon_crash.py exercises three co-op contexts and asserts the game process survives each unload:
  - host unloads a weapon on one of its own base soldiers
  - client unloads a weapon on one of its own base soldiers
  - a soldier is transferred host to client base, then the client reloads and unloads a weapon on a soldier at that base (the transferred-soldier case)

Verified the test crashes the process without the fix (socket reset at the null deref) and passes with the fix applied.

## Files changed

- src/Battlescape/Inventory.cpp: the fix
- src/Battlescape/InventoryState.h: test-only getInventoryForTest() accessor
- src/CoopMod/TestServer.cpp: inventory_unload command
- tools/coop_test/test_unload_weapon_crash.py: regression test
