### PR TITLE
feat(coop): make crash logs actionable and add minidumps

### DIFF
--- a/src/CoopMod/CrashHandler.cpp
+++ b/src/CoopMod/CrashHandler.cpp
@@ -10,58 +10,12 @@
 #include <sstream>
 #include <string>
 
+#include "../version.h"
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
-// ---- Minimal DbgHelp bits (no <DbgHelp.h> include) ----
-
-typedef unsigned long ULONG;
-typedef unsigned long long ULONG64;
-
-typedef struct _SYMBOL_INFO
-{
-	ULONG SizeOfStruct;
-	ULONG TypeIndex;
-	ULONG64 Reserved[2];
-	ULONG Index;
-	ULONG Size;
-	ULONG64 ModBase;
-	ULONG Flags;
-	ULONG64 Value;
-	ULONG64 Address;
-	ULONG Register;
-	ULONG Scope;
-	ULONG Tag;
-	ULONG NameLen;
-	ULONG MaxNameLen;
-	CHAR Name[1];
-} SYMBOL_INFO, *PSYMBOL_INFO;
-
-typedef struct _IMAGEHLP_LINE64
-{
-	DWORD SizeOfStruct;
-	PVOID Key;
-	DWORD LineNumber;
-	PCHAR FileName;
-	DWORD64 Address;
-} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
-
-// DbgHelp options flags (same values as in dbghelp.h)
-#define SYMOPT_CASE_INSENSITIVE 0x00000001
-#define SYMOPT_UNDNAME 0x00000002
-#define SYMOPT_DEFERRED_LOADS 0x00000004
-#define SYMOPT_LOAD_LINES 0x00000010
-
-extern "C"
-{
-	DWORD WINAPI SymSetOptions(DWORD SymOptions);
-	BOOL WINAPI SymInitialize(HANDLE hProcess, PCSTR UserSearchPath, BOOL fInvadeProcess);
-	BOOL WINAPI SymFromAddr(HANDLE hProcess, DWORD64 Address, PDWORD64 Displacement, PSYMBOL_INFO Symbol);
-	BOOL WINAPI SymGetLineFromAddr64(HANDLE hProcess, DWORD64 qwAddr, PDWORD pdwDisplacement, PIMAGEHLP_LINE64 Line64);
-}
-
-extern "C" USHORT WINAPI RtlCaptureStackBackTrace(ULONG FramesToSkip, ULONG FramesToCapture, PVOID* BackTrace, PULONG BackTraceHash);
+#include <dbghelp.h>
 
 #pragma comment(lib, "Dbghelp.lib")
 
@@ -131,61 +85,70 @@ static void localtime_safe(std::time_t t, std::tm& outTm)
 #endif
 }
 
-FILE* openCrashFile()
+// Build a "crash_<timestamp>_<seq>.<ext>" path inside the crash-log dir. The
+// same stamp is reused for a crash's .log and .dmp so they pair up on disk.
+void makeCrashPath(char* out, size_t n, unsigned seq, const char* ext)
 {
 	initLogDir();
 
-	// Use millisecond timestamp + sequence to avoid collisions (and repeated headers in the same file).
 	const auto now = std::chrono::system_clock::now();
 	const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
-
 	const std::time_t tt = std::chrono::system_clock::to_time_t(now);
 	std::tm lt{};
 	localtime_safe(tt, lt);
 
-	const unsigned seq = g_fileSeq.fetch_add(1, std::memory_order_relaxed);
-
-	char filePath[1400];
-
+	const char sep =
 #ifdef _WIN32
+		'\\';
+#else
+		'/';
+#endif
+
 	std::snprintf(
-		filePath,
-		sizeof(filePath),
-		"%s\\crash_%04d%02d%02d_%02d%02d%02d_%03lld_%u.log",
-		g_logDir,
+		out, n,
+		"%s%ccrash_%04d%02d%02d_%02d%02d%02d_%03lld_%u.%s",
+		g_logDir, sep,
 		lt.tm_year + 1900, lt.tm_mon + 1, lt.tm_mday,
 		lt.tm_hour, lt.tm_min, lt.tm_sec,
 		(long long)ms.count(),
-		seq);
-#else
-	std::snprintf(
-		filePath,
-		sizeof(filePath),
-		"%s/crash_%04d%02d%02d_%02d%02d%02d_%03lld_%u.log",
-		g_logDir,
-		lt.tm_year + 1900, lt.tm_mon + 1, lt.tm_mday,
-		lt.tm_hour, lt.tm_min, lt.tm_sec,
-		(long long)ms.count(),
-		seq);
-#endif
-
-	FILE* f = std::fopen(filePath, "a");
-	if (!f)
-		return nullptr;
-
-	char timeBuf[64];
-#ifdef _WIN32
-	std::strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%d %H:%M:%S", &lt);
-#else
-	std::strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%d %H:%M:%S", &lt);
-#endif
-
-	std::fprintf(f, "==== Crash/Log ====\n");
-	std::fprintf(f, "Time: %s.%03lld\n", timeBuf, (long long)ms.count());
-	return f;
+		seq, ext);
 }
 
 #ifdef _WIN32
+// Emit a build-identity block so an address in this log can be tied back to the
+// exact binary (and thus its PDB). ASLR is off (RandomizedBaseAddress=false),
+// so ExceptionAddress = ImageBase + RVA; logging the base + the PE link
+// timestamp lets a dev pick the matching build and compute the RVA offline.
+void writeBuildIdentity(FILE* f)
+{
+	std::fprintf(f, "Version: %s%s\n", OPENXCOM_VERSION_SHORT, OPENXCOM_VERSION_GIT);
+	std::fprintf(f, "Compiled: %s %s\n", __DATE__, __TIME__);
+
+	HMODULE mod = GetModuleHandleA(nullptr);
+	if (!mod)
+		return;
+
+	char modPath[MAX_PATH] = {0};
+	GetModuleFileNameA(mod, modPath, MAX_PATH);
+
+	// PE header -> link TimeDateStamp + SizeOfImage (fingerprint the binary).
+	DWORD timeStamp = 0, imageSize = 0;
+	auto* dos = (IMAGE_DOS_HEADER*)mod;
+	if (dos->e_magic == IMAGE_DOS_SIGNATURE)
+	{
+		auto* nt = (IMAGE_NT_HEADERS*)((BYTE*)mod + dos->e_lfanew);
+		if (nt->Signature == IMAGE_NT_SIGNATURE)
+		{
+			timeStamp = nt->FileHeader.TimeDateStamp;
+			imageSize = nt->OptionalHeader.SizeOfImage;
+		}
+	}
+
+	std::fprintf(f, "Module: %s\n", modPath);
+	std::fprintf(f, "ImageBase: 0x%llX  SizeOfImage: 0x%lX  PE-TimeDateStamp: 0x%08lX\n",
+		(unsigned long long)(DWORD64)mod, (unsigned long)imageSize, (unsigned long)timeStamp);
+}
+
 bool g_symbolsInitialized = false;
 
 void initSymbols()
@@ -200,42 +163,201 @@ void initSymbols()
 		g_symbolsInitialized = true;
 }
 
+// Format an address as "module+0xRVA symbolName (file:line) [0xABSOLUTE]".
+// The module+RVA form is ASLR-independent and resolvable offline against the
+// matching PDB/map; the symbol/line parts only appear when a PDB is present.
 std::string formatAddress(void* addr)
 {
 	std::ostringstream oss;
 	DWORD64 address = (DWORD64)addr;
 
-	oss << "0x" << std::hex << address;
+	// module + RVA (works with no PDB at all)
+	HMODULE mod = nullptr;
+	if (GetModuleHandleExA(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			(LPCSTR)addr, &mod) && mod)
+	{
+		char modPath[MAX_PATH] = {0};
+		GetModuleFileNameA(mod, modPath, MAX_PATH);
+		const char* base = std::strrchr(modPath, '\\');
+		base = base ? base + 1 : modPath;
+		oss << base << "+0x" << std::hex << (address - (DWORD64)mod);
+	}
+	else
+	{
+		oss << "0x" << std::hex << address;
+	}
 
 	initSymbols();
-	if (!g_symbolsInitialized)
-		return oss.str();
-
-	HANDLE process = GetCurrentProcess();
-
-	// symbol name
-	char buffer[sizeof(SYMBOL_INFO) + 256] = {};
-	PSYMBOL_INFO sym = (PSYMBOL_INFO)buffer;
-	sym->SizeOfStruct = sizeof(SYMBOL_INFO);
-	sym->MaxNameLen = 255;
-
-	if (SymFromAddr(process, address, 0, sym))
+	if (g_symbolsInitialized)
 	{
-		oss << " " << sym->Name;
+		HANDLE process = GetCurrentProcess();
+
+		char buffer[sizeof(SYMBOL_INFO) + 256] = {};
+		PSYMBOL_INFO sym = (PSYMBOL_INFO)buffer;
+		sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+		sym->MaxNameLen = 255;
+		DWORD64 symDisp = 0;
+		if (SymFromAddr(process, address, &symDisp, sym))
+			oss << " " << sym->Name << "+0x" << std::hex << symDisp;
+
+		IMAGEHLP_LINE64 line;
+		DWORD disp = 0;
+		std::memset(&line, 0, sizeof(line));
+		line.SizeOfStruct = sizeof(line);
+		if (SymGetLineFromAddr64(process, address, &disp, &line))
+			oss << " (" << line.FileName << ":" << std::dec << line.LineNumber << ")";
 	}
 
-	// file:line
-	IMAGEHLP_LINE64 line;
-	DWORD disp = 0;
-	std::memset(&line, 0, sizeof(line));
-	line.SizeOfStruct = sizeof(line);
-
-	if (SymGetLineFromAddr64(process, address, &disp, &line))
-	{
-		oss << " (" << line.FileName << ":" << line.LineNumber << ")";
-	}
-
+	oss << " [0x" << std::hex << address << "]";
 	return oss.str();
+}
+
+// Walk the faulting thread using its captured CONTEXT (StackWalk64), rather than
+// RtlCaptureStackBackTrace on the handler's own stack. This yields the real
+// crash frames, including those below the exception dispatcher.
+void writeStackWalk(FILE* f, const CONTEXT* ctxIn)
+{
+	if (!ctxIn)
+		return;
+
+	initSymbols();
+
+	CONTEXT ctx = *ctxIn; // StackWalk64 mutates the context
+	HANDLE process = GetCurrentProcess();
+	HANDLE thread = GetCurrentThread();
+
+	STACKFRAME64 frame;
+	std::memset(&frame, 0, sizeof(frame));
+	DWORD machine;
+#if defined(_M_X64)
+	machine = IMAGE_FILE_MACHINE_AMD64;
+	frame.AddrPC.Offset = ctx.Rip;
+	frame.AddrFrame.Offset = ctx.Rbp;
+	frame.AddrStack.Offset = ctx.Rsp;
+#elif defined(_M_IX86)
+	machine = IMAGE_FILE_MACHINE_I386;
+	frame.AddrPC.Offset = ctx.Eip;
+	frame.AddrFrame.Offset = ctx.Ebp;
+	frame.AddrStack.Offset = ctx.Esp;
+#else
+	machine = IMAGE_FILE_MACHINE_UNKNOWN;
+#endif
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrFrame.Mode = AddrModeFlat;
+	frame.AddrStack.Mode = AddrModeFlat;
+
+	std::fprintf(f, "Stack (faulting thread):\n");
+	for (int i = 0; i < 64; ++i)
+	{
+		if (!StackWalk64(machine, process, thread, &frame, &ctx,
+				nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr))
+			break;
+		if (frame.AddrPC.Offset == 0)
+			break;
+		std::fprintf(f, "  #%d %s\n", i, formatAddress((void*)frame.AddrPC.Offset).c_str());
+	}
+}
+
+// Write a minidump next to the .log so it can be opened in VS/WinDbg with the
+// matching PDB for a fully symbolized stack + locals.
+void writeMiniDump(unsigned seq, PEXCEPTION_POINTERS info)
+{
+	char dumpPath[1400];
+	makeCrashPath(dumpPath, sizeof(dumpPath), seq, "dmp");
+
+	HANDLE file = CreateFileA(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL, nullptr);
+	if (file == INVALID_HANDLE_VALUE)
+		return;
+
+	MINIDUMP_EXCEPTION_INFORMATION mei;
+	mei.ThreadId = GetCurrentThreadId();
+	mei.ExceptionPointers = info;
+	mei.ClientPointers = FALSE;
+
+	// Normal (stacks + thread contexts + module list) is enough to symbolize the
+	// crash; IndirectlyReferencedMemory pulls in what stack pointers point at
+	// (locals' objects) for a few MB more, rather than the tens of MB that
+	// WithDataSegs would add by dumping every global.
+	const MINIDUMP_TYPE type = (MINIDUMP_TYPE)(
+		MiniDumpNormal | MiniDumpWithThreadInfo |
+		MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithUnloadedModules);
+
+	MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), file, type,
+		info ? &mei : nullptr, nullptr, nullptr);
+
+	CloseHandle(file);
+}
+
+// A fatal SEH may unwind through a noexcept frame into std::terminate instead of
+// reaching SetUnhandledExceptionFilter, so more than one handler can race to dump.
+// Write exactly one minidump - from whichever handler first sees the crash (the
+// VEH, which still holds the real faulting CONTEXT).
+std::atomic<bool> g_dumpWritten{false};
+void tryWriteMiniDumpOnce(unsigned seq, PEXCEPTION_POINTERS info)
+{
+	bool expected = false;
+	if (g_dumpWritten.compare_exchange_strong(expected, true))
+		writeMiniDump(seq, info);
+}
+
+// Exception codes that mean the process is going down (as opposed to first-chance
+// exceptions the app catches and handles).
+static bool isFatalException(DWORD code)
+{
+	switch (code)
+	{
+	case 0xC0000005: // access violation
+	case 0xC00000FD: // stack overflow
+	case 0xC000001D: // illegal instruction
+	case 0xC0000094: // integer divide by zero
+	case 0xC0000096: // privileged instruction
+	case 0xC0000025: // noncontinuable exception
+	case 0xC0000026: // invalid disposition
+		return true;
+	default:
+		return false;
+	}
+}
+#endif // _WIN32
+
+FILE* openCrashFile()
+{
+	const unsigned seq = g_fileSeq.fetch_add(1, std::memory_order_relaxed);
+
+	char filePath[1400];
+	makeCrashPath(filePath, sizeof(filePath), seq, "log");
+
+	FILE* f = std::fopen(filePath, "a");
+	if (!f)
+		return nullptr;
+
+	const auto now = std::chrono::system_clock::now();
+	const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+	const std::time_t tt = std::chrono::system_clock::to_time_t(now);
+	std::tm lt{};
+	localtime_safe(tt, lt);
+
+	char timeBuf[64];
+	std::strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%d %H:%M:%S", &lt);
+
+	std::fprintf(f, "==== Crash/Log ====\n");
+	std::fprintf(f, "Time: %s.%03lld\n", timeBuf, (long long)ms.count());
+#ifdef _WIN32
+	writeBuildIdentity(f);
+#else
+	std::fprintf(f, "Version: %s%s\n", OPENXCOM_VERSION_SHORT, OPENXCOM_VERSION_GIT);
+	std::fprintf(f, "Compiled: %s %s\n", __DATE__, __TIME__);
+#endif
+	return f;
+}
+
+#ifdef _WIN32
+// This crash's seq is shared between the .log and the .dmp; grab it up front.
+static unsigned nextSeqPeek()
+{
+	return g_fileSeq.load(std::memory_order_relaxed);
 }
 
 static bool isErrorSeverity(DWORD code)
@@ -256,6 +378,8 @@ static bool isNoiseException(DWORD code)
 		return true; // breakpoint
 	case 0x80000004:
 		return true; // single-step
+	case 0xE06D7363:
+		return true; // MSVC C++ EH (thrown-and-caught std/other exceptions - noise first-chance)
 	default:
 		return false;
 	}
@@ -270,23 +394,21 @@ LONG WINAPI vectoredHandler(PEXCEPTION_POINTERS info)
 	if (isNoiseException(code) || !isErrorSeverity(code))
 		return EXCEPTION_CONTINUE_SEARCH;
 
+	const unsigned seq = nextSeqPeek();
 	FILE* f = openCrashFile();
 	if (f)
 	{
 		void* addr = info->ExceptionRecord->ExceptionAddress;
-		std::string addrStr = formatAddress(addr);
-
-		std::fprintf(f, "SEH exception (VEH). Code = 0x%08lX at %s\n", code, addrStr.c_str());
-
-		// Walk the faulting thread's stack (accurate with a PDB present).
-		void* frames[62];
-		USHORT frameCount = RtlCaptureStackBackTrace(0, 62, frames, nullptr);
-		std::fprintf(f, "Stack (%u frames):\n", (unsigned)frameCount);
-		for (USHORT i = 0; i < frameCount; ++i)
-			std::fprintf(f, "  #%u %s\n", (unsigned)i, formatAddress(frames[i]).c_str());
-
+		std::fprintf(f, "SEH exception (VEH, first-chance). Code = 0x%08lX at %s\n",
+			code, formatAddress(addr).c_str());
+		writeStackWalk(f, info->ContextRecord);
 		std::fclose(f);
 	}
+
+	// Capture a minidump here, while we still hold the faulting CONTEXT - the
+	// exception may otherwise reach std::terminate rather than unhandledFilter.
+	if (isFatalException(code))
+		tryWriteMiniDumpOnce(seq, info);
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -294,16 +416,20 @@ LONG WINAPI vectoredHandler(PEXCEPTION_POINTERS info)
 static LONG WINAPI unhandledFilter(PEXCEPTION_POINTERS info)
 {
 	// This runs when the process is actually going to crash (unhandled exception).
+	const unsigned seq = nextSeqPeek();
+
 	FILE* f = openCrashFile();
 	if (f)
 	{
 		const DWORD code = info->ExceptionRecord->ExceptionCode;
 		void* addr = info->ExceptionRecord->ExceptionAddress;
-
-		std::string addrStr = formatAddress(addr);
-		std::fprintf(f, "UNHANDLED SEH. Code = 0x%08lX at %s\n", code, addrStr.c_str());
+		std::fprintf(f, "UNHANDLED SEH (fatal). Code = 0x%08lX at %s\n",
+			code, formatAddress(addr).c_str());
+		writeStackWalk(f, info->ContextRecord);
 		std::fclose(f);
 	}
+
+	tryWriteMiniDumpOnce(seq, info);
 
 	return EXCEPTION_EXECUTE_HANDLER;
 }
@@ -351,11 +477,13 @@ void terminateHandler()
 		std::abort();
 	}
 
+	bool hadActiveException = false;
 	try
 	{
 		std::exception_ptr p = std::current_exception();
 		if (p)
 		{
+			hadActiveException = true;
 			try
 			{
 				std::rethrow_exception(p);
@@ -379,7 +507,13 @@ void terminateHandler()
 		std::fprintf(f, "Exception inside terminateHandler.\n");
 	}
 
-#ifndef _WIN32
+#ifdef _WIN32
+	// Backstop dump only for a real unhandled C++ exception. A "no active
+	// exception" std::terminate is how the game exits normally, so dumping there
+	// would litter a minidump on every clean shutdown.
+	if (hadActiveException)
+		tryWriteMiniDumpOnce(g_fileSeq.load(std::memory_order_relaxed), nullptr);
+#else
 	writeStackTrace(f);
 #endif
 


### PR DESCRIPTION
## Summary

Follow-up to the crash-logging point raised in the comments of #29. The CrashHandler logs were hard to act on: a report was usually a single line like

    SEH exception (VEH). Code = 0xC0000005 at 0x1404f9f80

with no build identity, no module or RVA, and a stack captured from the handler's own stack instead of the faulting thread. This PR makes the logs self-sufficient and adds minidumps.

## What changed

Build identity in every log:
- version string, compile timestamp, module path, image base, SizeOfImage, and the PE link TimeDateStamp.
- ASLR is off in all configs (RandomizedBaseAddress=false), so ExceptionAddress = ImageBase + RVA. This block lets a developer pick the exact build and resolve addresses against its PDB offline.

Better address formatting:
- each frame now prints module+0xRVA, then the symbol and file:line when a PDB is present, then the raw absolute address.
- the module+RVA form is ASLR-independent and resolvable with only the archived PDB or a linker map, so even logs from shipped PDB-less builds are usable.

Real faulting-thread stack:
- StackWalk64 over the exception ContextRecord replaces RtlCaptureStackBackTrace, so the actual crash frames are captured, including frames below the exception dispatcher.

Minidump:
- MiniDumpWriteDump writes a .dmp next to the .log on a fatal crash, from the VEH while the faulting context is still live. A fatal SEH can unwind through a noexcept frame into std::terminate and skip SetUnhandledExceptionFilter, so capturing in the VEH is what guarantees a dump with the crash context. A one-shot guard keeps it to a single dump per crash.
- dump type is Normal + ThreadInfo + IndirectlyReferencedMemory (a few hundred KB), not WithDataSegs (tens of MB). A clean shutdown produces no dump.

Noise reduction:
- the MSVC C++ EH code 0xE06D7363 is now filtered out of the first-chance VEH log so ordinary thrown-and-caught exceptions do not spam crashlogs.

Implementation note: switches from the hand-rolled DbgHelp declarations to including dbghelp.h for StackWalk64 and MiniDumpWriteDump. Dbghelp.lib was already linked.

## Before and after

Before:

    SEH exception (VEH). Code = 0xC0000005 at 0x1404f9f80

After (reproducing the #29 unload crash):

    Version: Extended 8.4.2 (v2025-10-06)
    Compiled: Jul 14 2026 23:18:53
    Module: ...\OpenXcom.exe
    ImageBase: 0x140000000  SizeOfImage: 0x498D000  PE-TimeDateStamp: 0x6A56FC20
    SEH exception (VEH, first-chance). Code = 0xC0000005 at OpenXcom.exe+0x535c90 ... [0x140535c90]
    Stack (faulting thread):
      #0 OpenXcom.exe+0x535c90 ... (nearest-symbol artifact)
      #1 OpenXcom.exe+0x260c87 OpenXcom::Inventory::moveItem+0x137 (src/Battlescape/Inventory.cpp:560) [0x140260c87]
      #2 OpenXcom.exe+0x262e12 OpenXcom::Inventory::unload+0x6f2 (src/Battlescape/Inventory.cpp:1747) [0x140262e12]
      #3 OpenXcom.exe+0xb0bb3 OpenXcom::TestServer::execute+0x7f03 (src/CoopMod/TestServer.cpp:1600) [0x1400b0bb3]
      ...

plus a ~250 KB minidump. Frame 0 is the usual wrong nearest-export name for an inlined call, but frame 1 onward pinpoints the fault.

## Testing

Built Release x64. Reproduced the #29 crash and confirmed the log and minidump above. Confirmed a clean shutdown writes no minidump.

## Follow-ups (not in this PR)

- There is no git SHA at compile time under the MSBuild build (git_version.h.in is CMake-only and unused here), so the build is fingerprinted by version plus PE TimeDateStamp. A pre-build step that stamps the git SHA would make matching exact.
- Archiving the PDB (or a linker map) per release is what fully unlocks offline symbolication of shipped-build logs.
- The existing "std::terminate called (no active exception)" line is still written on normal shutdown (pre-existing behavior); worth a separate look at why shutdown goes through std::terminate.
