### PR TITLE
fix(coop): survive a password-protected lobby join and leave it cleanly

### DIFF
--- a/src/CoopMod/LobbyMenu.cpp
+++ b/src/CoopMod/LobbyMenu.cpp
@@ -762,6 +762,13 @@ void LobbyMenu::btnCancelClick(Action*)
 
 void LobbyMenu::pushServerListUnlessPresent()
 {
+	// ServerList's ctor dereferences the SavedGame (getCountries()); a fresh
+	// client that never received a world (F2 lobby, mid-join rejoin) has none,
+	// so pushing the browser would crash - land back on the state underneath.
+	if (!_game->getSavedGame())
+	{
+		return;
+	}
 	for (auto* s : _game->getStates())
 	{
 		if (dynamic_cast<ServerList*>(s) != nullptr)

--- a/src/CoopMod/PasswordCheckMenu.cpp
+++ b/src/CoopMod/PasswordCheckMenu.cpp
@@ -196,6 +196,12 @@ void PasswordCheckMenu::joinTCPGame(Action* action)
 
 }
 
+void PasswordCheckMenu::submitPassword(const std::string &password)
+{
+	_password->setText(password);
+	joinTCPGame(nullptr);
+}
+
 void PasswordCheckMenu::think()
 {
 	State::think();

--- a/src/CoopMod/PasswordCheckMenu.h
+++ b/src/CoopMod/PasswordCheckMenu.h
@@ -108,6 +108,8 @@ class PasswordCheckMenu : public State
 	void init() override;
 	void btnCancelClick(Action *action);
 	void joinTCPGame(Action *action);
+	/// Fills the password box and clicks JOIN (test-harness entry point).
+	void submitPassword(const std::string &password);
 	/// Runs the timers and handles popups.
 	void think() override;
 };

--- a/src/CoopMod/TestServer.cpp
+++ b/src/CoopMod/TestServer.cpp
@@ -96,6 +96,7 @@
 #include "Profile.h"
 #include "connectionTCP.h"
 #include "ServerList.h"
+#include "PasswordCheckMenu.h"
 #include "../Engine/Screen.h"
 #include "../Basescape/BasescapeState.h"
 #include "../Basescape/SoldiersState.h"
@@ -1045,8 +1046,9 @@ std::string TestServer::execute(const std::string& line)
 				{
 					connectionTCP::session.lobbyMode = _game->getSavedGame()->getCoopPlayers().empty() ? 1 : 2;
 				}
-				connectionTCP::password = "";
-				connectionTCP::isPasswordRequired = false;
+				// optional room password (default: open server, like an empty UI box)
+				connectionTCP::password = req.get("password", "").asString();
+				connectionTCP::isPasswordRequired = !connectionTCP::password.empty();
 				connectionTCP::_coopGamemode = 1; // PVE
 				coop->setCoopSession(false);
 				coop->setPlayerTurn(3);
@@ -1160,6 +1162,21 @@ std::string TestServer::execute(const std::string& line)
 			// explicitly right before join_tcp.
 			_game->pushState(new CoopState(15));
 			resp["ok"] = true;
+		}
+		else if (cmd == "password_join")
+		{
+			// fill the PasswordCheckMenu password box and click JOIN, like a
+			// player answering the host's password challenge
+			PasswordCheckMenu* pw = topState<PasswordCheckMenu>(_game);
+			if (!pw)
+			{
+				resp["error"] = "no PasswordCheckMenu on top";
+			}
+			else
+			{
+				pw->submitPassword(req.get("password", "").asString());
+				resp["ok"] = true;
+			}
 		}
 		else if (cmd == "coop_dialog_back")
 		{

--- a/src/CoopMod/connectionTCP.cpp
+++ b/src/CoopMod/connectionTCP.cpp
@@ -2752,12 +2752,32 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 	if (stateString == "tcp_password")
 	{
 
-		onConnect = -5;
+		// A bounce while the prompt is already up means the password the
+		// player submitted was wrong: let updateCoopTask() raise the
+		// "Incorrect password" dialog (441). The FIRST bounce is only the
+		// challenge; flagging it -5 too made 441 bury the prompt on the
+		// next frame, before the player could type anything.
+		bool promptAlreadyOpen = false;
+		for (State* s : _game->getStates())
+		{
+			if (dynamic_cast<PasswordCheckMenu*>(s) != nullptr)
+			{
+				promptAlreadyOpen = true;
+				break;
+			}
+		}
 
-		connectionTCP::forceCloseCoopStateMenu = true;
+		if (promptAlreadyOpen)
+		{
+			onConnect = -5;
+		}
+		else
+		{
+			connectionTCP::forceCloseCoopStateMenu = true;
 
-		// If this room/server requires a password, open passwordCheck menu.
-		_game->pushState(new PasswordCheckMenu(ipAddress, _game->getCoopMod()->getHostName(), tcp_port, false, true));
+			// If this room/server requires a password, open passwordCheck menu.
+			_game->pushState(new PasswordCheckMenu(ipAddress, _game->getCoopMod()->getHostName(), tcp_port, false, true));
+		}
 
 	}
 
@@ -7306,10 +7326,14 @@ void connectionTCP::onTCPMessage(std::string stateString, Json::Value obj)
 		// once buried (a non-top state gets no think() tick, and LobbyMenu's ctor
 		// clears the flag anyway), so it would linger and resurface as a stale
 		// "Connecting..." window when the client later leaves the lobby.
+		// A password join buries [Connecting, PasswordCheckMenu, Connecting]
+		// (JOIN pushes a second wait dialog), so pop the stale password menu
+		// too, not just a run of Connecting dialogs (issue #46).
 		while (!_game->getStates().empty())
 		{
-			CoopState* connecting = dynamic_cast<CoopState*>(_game->getStates().back());
-			if (connecting && connecting->getStateCode() == 15)
+			State* top = _game->getStates().back();
+			CoopState* connecting = dynamic_cast<CoopState*>(top);
+			if ((connecting && connecting->getStateCode() == 15) || dynamic_cast<PasswordCheckMenu*>(top) != nullptr)
 				_game->popState();
 			else
 				break;

--- a/tools/coop_test/test_lobby_dialogs.py
+++ b/tools/coop_test/test_lobby_dialogs.py
@@ -3,6 +3,10 @@
 1. Host new game -> client joins lobby -> client disconnects -> the client must
    NOT be left staring at a lingering "Connecting..." wait dialog (CoopState 15)
    that was buried under the lobby and never popped.
+   Password variant (issue #46 family): a password-protected join detours
+   through PasswordCheckMenu and pushes a SECOND "Connecting..." dialog, so the
+   stack under the lobby is [Connecting, PasswordCheckMenu, Connecting]; leaving
+   the lobby must not resurface the buried password menu or either dialog.
 2. New game, all bases placed: the host dialog must read "All bases placed." with
    a "BEGIN" button (was "All players connected" / "RESUME").
 3. The host's "waiting for bases" dialog must use the SAME message and compact
@@ -36,13 +40,28 @@ def dlg(gc):
     return gc.cmd({"cmd": "coop_dialog_info"})
 
 
-def _host_lobby(host, port):
+def _host_lobby(host, port, password=None):
     host.ok({"cmd": "open_new_game", "mode": "coop"})
     host.wait_for("difficulty", lambda: session.has_state(host, "NewGameState"))
     host.ok({"cmd": "newgame_ok"})
     host.wait_for("host window", lambda: session.has_state(host, "HostMenu"))
-    host.ok({"cmd": "host_tcp", "server": "TestSrv", "port": port, "player": "HostPlayer"})
+    req = {"cmd": "host_tcp", "server": "TestSrv", "port": port, "player": "HostPlayer"}
+    if password:
+        req["password"] = password
+    host.ok(req)
     host.wait_for("host lobby", lambda: session.has_state(host, "LobbyMenu"))
+
+
+def _client_at_server_browser(client):
+    """Client with its own solo world sitting in the server browser, the state
+    a real player joins from (a ServerList ends up under the join dialogs)."""
+    client.ok({"cmd": "open_new_game", "mode": "solo"})
+    client.wait_for("client difficulty", lambda: session.has_state(client, "NewGameState"))
+    client.ok({"cmd": "newgame_ok"})
+    client.wait_for("client base", lambda: session.has_state(client, "BuildNewBaseState"))
+    client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "SoloBase"})
+    client.ok({"cmd": "open_server_browser"})
+    client.wait_for("client browser", lambda: session.has_state(client, "ServerList"))
 
 
 def _campaign_lobby(host, client, port):
@@ -62,13 +81,7 @@ def test_connecting_dialog_cleared():
 
         # The real join flow: the client has its own world and browses servers,
         # so a ServerList sits under the "Connecting..." dialog and the lobby.
-        client.ok({"cmd": "open_new_game", "mode": "solo"})
-        client.wait_for("client difficulty", lambda: session.has_state(client, "NewGameState"))
-        client.ok({"cmd": "newgame_ok"})
-        client.wait_for("client base", lambda: session.has_state(client, "BuildNewBaseState"))
-        client.ok({"cmd": "place_first_base", "lon": LAND_LON, "lat": LAND_LAT, "name": "SoloBase"})
-        client.ok({"cmd": "open_server_browser"})
-        client.wait_for("client browser", lambda: session.has_state(client, "ServerList"))
+        _client_at_server_browser(client)
 
         _host_lobby(host, "47910")
 
@@ -87,6 +100,53 @@ def test_connecting_dialog_cleared():
         assert "Connecting" not in (d.get("title") or ""), \
             f"BUG1: Connecting text still showing: {d}"
         print("PASS bug1: no lingering Connecting... after lobby disconnect")
+    finally:
+        host.shutdown(); client.shutdown()
+
+
+# ------------------------------------------------- bug 1, password variant
+def test_connecting_dialog_cleared_password():
+    """Issue #46 family: the same leave-the-lobby scenario, but the host
+    requires a password. The join then detours through PasswordCheckMenu and
+    the JOIN click pushes a SECOND "Connecting..." dialog, so the stack under
+    the lobby is [Connecting, PasswordCheckMenu, Connecting].
+
+    The client deliberately has NO world of its own (the F2 fresh-join flow):
+    a campaign client's disconnect happens to rebuild the whole state stack,
+    but a fresh client keeps its stack, so the buried dialogs would resurface
+    one by one as the player backs out. Leaving the lobby must resurface none
+    of them."""
+    host = GameClient("host", 48727, make_user_dir("dlg1pw_host"))
+    client = GameClient("client", 48728, make_user_dir("dlg1pw_client"))
+    try:
+        host.spawn(); client.spawn()
+        host.connect(); client.connect()
+
+        _host_lobby(host, "47913", password="s3cret")
+
+        # mirror ServerList: push the "Connecting..." dialog, then join; the
+        # passwordless hello bounces into the password prompt
+        client.ok({"cmd": "coop_push_connecting"})
+        client.ok({"cmd": "join_tcp", "ip": "127.0.0.1", "port": "47913", "player": "ClientPlayer"})
+        client.wait_for("password prompt",
+                        lambda: session.has_state(client, "PasswordCheckMenu"))
+
+        # answering the challenge pushes the second Connecting... and reconnects
+        client.ok({"cmd": "password_join", "password": "s3cret"})
+        client.wait_for("client lobby", lambda: session.has_state(client, "LobbyMenu"))
+
+        # client leaves the lobby -> no stale password menu, no Connecting...
+        client.ok({"cmd": "lobby_disconnect"})
+        time.sleep(3)  # let the client's think()/teardown settle
+
+        d = dlg(client)
+        assert not (d.get("present") and d.get("code") == 15), \
+            f"BUG1pw: stale Connecting... dialog after lobby disconnect: {d}"
+        assert "Connecting" not in (d.get("title") or ""), \
+            f"BUG1pw: Connecting text still showing: {d}"
+        assert not session.has_state(client, "PasswordCheckMenu"), \
+            f"BUG1pw: stale PasswordCheckMenu after lobby disconnect: {session.states(client)}"
+        print("PASS bug1pw: no stale password/Connecting dialogs after lobby disconnect")
     finally:
         host.shutdown(); client.shutdown()
 
@@ -180,6 +240,7 @@ def test_rejoin_hold_and_freeze():
 
 def main():
     test_connecting_dialog_cleared()
+    test_connecting_dialog_cleared_password()
     test_wait_bases_dialog()
     test_rejoin_hold_and_freeze()
     print("ALL LOBBY DIALOG TESTS PASSED")


### PR DESCRIPTION
# Fix password-protected lobby join + leave (issue #46 family)

## Context

Issue #46 ("client closes the lobby → stale Connecting... popup") is already fixed on main for the plain join path (PR #36, `e378c2d0e`): its regression test (`test_lobby_dialogs.py::test_connecting_dialog_cleared`) passes against a main build, and the scenario was also manually verified as non-reproducible. All published releases predate that fix, so the original report was from a stale build.

Investigating the same family on the **password-protected** join path found it broken end-to-end on the client:

## Fixes (`fix(coop)` commit)

1. **Password prompt insta-killed.** The first `tcp_password` challenge set `onConnect = -5`; `updateCoopTask()` treats `-5` as "wrong password" and on the very next frame pushed CoopState(441) "Incorrect password. Connection closed." and disconnected — before the player could type anything. Now `-5` is only flagged when the prompt is already open (a genuinely wrong submitted password); the first bounce just shows the prompt.
2. **Stale dialogs after leaving the lobby (the #46 symptom).** A password join buries `[Connecting, PasswordCheckMenu, Connecting]` under the LobbyMenu (JOIN pushes a second wait dialog). The join-accept handler only popped the top run of Connecting dialogs, so leaving the lobby resurfaced a dead password menu and then a stale "Connecting..." window that forced an extra Cancel. The handler now pops the buried password menu together with the wait dialogs.
3. **Crash on leaving the lobby without a world.** `LobbyMenu::pushServerListUnlessPresent()` constructed `ServerList`, whose ctor dereferences the SavedGame (`getCountries()`, ServerList.cpp:347) — an access violation for a fresh client that never received a world. Now skipped when there is no save.

## Regression test (`test(coop)` commit)

- Harness: `host_tcp` gains an optional `password`; new `password_join` command types the password into `PasswordCheckMenu` and clicks JOIN (via a small `submitPassword()` entry point).
- `test_lobby_dialogs.py::test_connecting_dialog_cleared_password`: fresh no-world client joins a password-protected lobby and leaves it; asserts no stale `PasswordCheckMenu` and no `Connecting...` dialog remain. Verified red without the fix commit (reproduces the exact #46 symptom: `{'code': 15, 'title': 'Connecting...', 'backText': 'CANCEL'}` after leaving) and green with it.

## Validation

Lobby/session sweep, headless (SDL dummy drivers): test_lobby_dialogs, test_lobby_gating, test_lobby_polish, test_new_campaign_flow, test_rejoin_flow, test_resume_flow, test_session_hardening, test_server_browser — all PASS. Rebased onto main after #48 and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
