### PR TITLE
fix(coop): guard null-SavedGame derefs in coop menu entry points

### DIFF
--- a/src/CoopMod/CoopMenu.cpp
+++ b/src/CoopMod/CoopMenu.cpp
@@ -218,8 +218,8 @@ CoopMenu::CoopMenu() : _craft(0), _selectType(NewBattleSelectType::MISSION), _is
 	_cbxGameMode->setOptions(_gamemodeTypes, false);
 	_cbxGameMode->onChange((ActionHandler)&CoopMenu::cbxGameModeChange);
 
-	// check if campaign mission
-	if (!_game->getSavedGame()->getCountries()->empty())
+	// check if campaign mission (no loaded game = not a campaign)
+	if (_game->getSavedGame() && !_game->getSavedGame()->getCountries()->empty())
 	{
 		_game->getCoopMod()->setCoopCampaign(true);
 	}
@@ -399,7 +399,7 @@ void CoopMenu::init()
 		}
 	}
 
-	if (_game->getSavedGame()->getSavedBattle())
+	if (_game->getSavedGame() && _game->getSavedGame()->getSavedBattle())
 	{
 
 		// check if already converted units...
@@ -666,7 +666,7 @@ void CoopMenu::joinTCPGame(Action *action)
 
 	bool convert = true;
 
-	if (_game->getSavedGame()->getSavedBattle())
+	if (_game->getSavedGame() && _game->getSavedGame()->getSavedBattle())
 	{
 
 		// check if already converted units...
@@ -733,7 +733,7 @@ void CoopMenu::hostTCPGame(Action *action)
 
 	bool convert = true;
 
-	if (_game->getSavedGame()->getSavedBattle())
+	if (_game->getSavedGame() && _game->getSavedGame()->getSavedBattle())
 	{
 
 		// check if already converted units...
@@ -813,7 +813,7 @@ void CoopMenu::disconnect(Action *action)
 
 	
 
-	if (_game->getSavedGame()->getSavedBattle())
+	if (_game->getSavedGame() && _game->getSavedGame()->getSavedBattle())
 	{
 
 		// check if already converted units...

--- a/src/CoopMod/ServerList.cpp
+++ b/src/CoopMod/ServerList.cpp
@@ -343,8 +343,9 @@ ServerList::ServerList() : _sortable(true)
 
 	updateArrows();
 
-	// check if campaign
-	if (!_game->getSavedGame()->getCountries()->empty())
+	// check if campaign (no loaded game = not a campaign; guard the deref so
+	// a save-less path into the browser cannot crash here)
+	if (_game->getSavedGame() && !_game->getSavedGame()->getCountries()->empty())
 	{
 		_game->getCoopMod()->setCoopCampaign(true);
 	}


### PR DESCRIPTION
Defensive follow-up to #51, same crash family: coop UI entry points that assume a loaded game exists.

- **ServerList ctor** read `getSavedGame()->getCountries()` unguarded (ServerList.cpp:347). #51 guarded one call site (`LobbyMenu::pushServerListUnlessPresent`); this guards the ctor itself so any other save-less path into the browser (e.g. `connectionTCP::createCoopMenu`) cannot crash.
- **CoopMenu**: the ctor's campaign check (`getCountries()`) and the four join/host actions' battle-conversion checks (`getSavedBattle()`) dereferenced `getSavedGame()` unguarded.

No loaded game now means "not a campaign / nothing to convert" instead of an access violation. Not reachable from the stock UI today (the browser and coop menu open from states that have a save), so this is hardening, not a live crash fix.

Validation: x64 Release build clean; `test_lobby_dialogs.py` (6/6 incl. the #51 password variant) and `test_server_browser.py` pass headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)