### PR TITLE
ci: reset rolling nightly release each run (fix notes dup + asset buildup)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -205,6 +205,20 @@ jobs:
           git tag -f nightly
           git push -f origin nightly
 
+      - name: Reset rolling nightly release (avoid notes + asset buildup)
+        if: success() && steps.meta.outputs.channel == 'nightly'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The nightly tag/release rolls. Re-publishing to it appends release notes
+          # and accumulates versioned assets (old x64/WinXP/Linux files never get
+          # overwritten). Delete the previous nightly RELEASE (keep the just-moved
+          # tag) so Publish recreates it fresh: correct notes + only this run's assets.
+          gh release delete nightly --repo "$env:GITHUB_REPOSITORY" --yes 2>$null
+          $global:LASTEXITCODE = 0
+          Write-Host "Cleared previous nightly release (if any)"
+
       - name: Publish
         if: success()
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Fixes two nightly-release issues reported after the CI unification:

1. **Release notes kept duplicating/growing** — softprops re-publishing to the rolling `nightly` release appended auto-generated notes each run.
2. **Assets accumulated** — the x64/WinXP/Linux asset filenames include the version (which changes every nightly), so softprops never overwrote the old ones; the asset list grew unbounded.

**Fix:** before the Publish step (nightly channel only), delete the previous `nightly` release (keeping the just-moved tag). Publish then recreates it fresh — correct notes and only the current run's three assets. Versioned `v*` releases are untouched (each tag is a distinct release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)