### PR TITLE
fix(ci): join gh body lines before stripping nightly notes (fixes mangled notes)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -246,9 +246,14 @@ jobs:
           # "New Contributors" is meaningless on a rolling tag: GitHub recomputes it each
           # run against a shifting base (the last release tag) and flags even the original
           # dev as "new". Remove that section, keeping "## What's Changed" + "Full Changelog".
-          $body  = gh release view nightly --repo "$env:GITHUB_REPOSITORY" --json body --jq '.body'
-          $clean = [regex]::Replace($body, "(?s)\r?\n?## New Contributors\r?\n(?:\*.*\r?\n?)*?(?=\r?\n?\*\*Full Changelog\*\*)", "`n")
+          # NOTE: gh returns the body as a string[] (one element per line). Without an
+          # explicit -join, PowerShell coerces it to a single string joined with SPACES,
+          # which destroys every newline (notes render as one run-on paragraph) and makes
+          # the regex below never match. Always -join "`n" first.
+          $body  = (gh release view nightly --repo "$env:GITHUB_REPOSITORY" --json body --jq '.body') -join "`n"
+          $clean = [regex]::Replace($body, "(?s)\r?\n?## New Contributors\r?\n(?:\*.*\r?\n?)*\r?\n?(?=\*\*Full Changelog\*\*)", "`n`n")
           Set-Content nightly-notes.md $clean -Encoding utf8
+          if ($clean -notmatch "## What's Changed") { throw "nightly notes look wrong after strip - aborting rather than publishing mangled notes" }
           gh release edit nightly --repo "$env:GITHUB_REPOSITORY" --notes-file nightly-notes.md
           Write-Host "Stripped 'New Contributors' from nightly notes"
 


### PR DESCRIPTION
Follow-up to #58, which **broke** the nightly notes instead of fixing them (see the 8.4.13201 release).

**Bug:** `gh release view ... --jq '.body'` returns a **string[]** (one element per line). Passing that to `[regex]::Replace()` makes PowerShell coerce it to a string joined with **spaces**, so:
1. Every newline was destroyed → notes rendered as one giant run-on paragraph.
2. The regex (which anchors on `\n## New Contributors\n`) never matched → the bogus "New Contributors" section survived anyway.

**Fix:**
- `-join "`n"` the gh output before the regex (the actual bug).
- Align the regex with the version validated against the real body (keeps a blank line before `**Full Changelog**`).
- Add a sanity check: abort if `## What's Changed` is missing after the strip, rather than publishing mangled notes.

The live `nightly` release has already been repaired by hand (regenerated + stripped); this makes future nightlies correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)