### PR TITLE
fix(coop): guard SDLNet init/quit refcount to kill test_server_browser flake

### DIFF
--- a/src/CoopMod/connectionUDP/rendezvous_client.cpp
+++ b/src/CoopMod/connectionUDP/rendezvous_client.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <vector>
 
@@ -383,18 +384,44 @@ bool receiveSignedMessage(TcpCtx& ctx,
 	return true;
 }
 
+// SDL_net's global init counter (SDLNet_started) is a plain non-atomic int and
+// SDLNet_Quit() runs WSACleanup() on the 1->0 edge, tearing down every Winsock
+// handle process-wide. Multiple probe/list threads calling initCommon/quitCommon
+// concurrently would race that counter and could drive it to 0 while another
+// thread (e.g. the coop TestServer's socket loop) is mid-call -> forced RST /
+// crash. Guard our own paired init/quit with a mutex + refcount so this
+// subsystem performs exactly one real SDLNet_Init/SDLNet_Quit and never quits
+// below its own outstanding-use floor.
+std::mutex& sdlnetRefMutex()
+{
+	static std::mutex m;
+	return m;
+}
+int g_sdlnetRefs = 0; // guarded by sdlnetRefMutex()
+
 bool initCommon()
 {
+	std::lock_guard<std::mutex> lock(sdlnetRefMutex());
+	// sodium_init() is idempotent; keep it under the lock so the first-call
+	// initialization is never entered concurrently.
 	if (sodium_init() < 0)
 		return false;
-	if (SDLNet_Init() == -1)
-		return false;
+	if (g_sdlnetRefs == 0)
+	{
+		if (SDLNet_Init() == -1)
+			return false;
+	}
+	++g_sdlnetRefs;
 	return true;
 }
 
 void quitCommon()
 {
-	SDLNet_Quit();
+	std::lock_guard<std::mutex> lock(sdlnetRefMutex());
+	if (g_sdlnetRefs == 0)
+		return; // floor: never SDLNet_Quit() below our own init count
+	if (--g_sdlnetRefs == 0)
+		SDLNet_Quit();
 }
 
 bool validateCommon(const RendezvousClient::CommonConfig& cfg, std::string* error)


### PR DESCRIPTION
## Problem

`test_server_browser` flaked in CI (run [29547253818](https://github.com/OpenXcom-Coop/OpenXcom-Coop-Mod/actions/runs/29547253818), main #58): first attempt died with `ConnectionResetError [WinError 10054]` while polling `server_combo`; retry-once masked it. The RST means the game process's Winsock state was torn down under the TestServer socket — not a test timeout.

## Root cause

`ServerList` with ≥2 offline servers fires **one detached `std::thread` per server** (`connection_rendezvous_glue.cpp:126`). Each probe → `listRooms` → `initCommon()`/`quitCommon()`, which called `SDLNet_Init()`/`SDLNet_Quit()` directly with **no refcount**.

SDL_net's `SDLNet_started` is a plain non-atomic int, and `SDLNet_Quit()` runs `WSACleanup()` on the 1→0 edge — tearing down **every Winsock handle process-wide**. Two probe threads (plus the TestServer's own `SDLNet_Init` at `TestServer.cpp:173`) race that counter and can drive it to 0 while another thread is mid socket-call → forced RST / crash. Thread-timing dependent ⇒ flaky. Refused ports return fast, so the two init/quit windows overlap tightly = max race pressure.

## Fix

Guard `initCommon()`/`quitCommon()` in `rendezvous_client.cpp` with a mutex + own refcount so the rendezvous subsystem performs **exactly one** real `SDLNet_Init`/`SDLNet_Quit` regardless of concurrent probes, and never quits below its own outstanding-use floor. `sodium_init()` moved under the lock so first-call init is never entered concurrently.

## Scope note

`connectionTCP.cpp`, `connectionUDP.cpp`, `connection_lan_discovery.cpp`, `rendezvous_server.cpp` still call raw `SDLNet_Init`/`SDLNet_Quit` — same latent counter-race, smaller exposure. Left out of this fix; route through the guarded pair if it recurs.

## Verification

- Release x64 relink clean (no C1083/C1060/LNK).
- `test_server_browser` local **6/6 pass**.
- Race is intermittent, so local passes confirm no regression but can't prove elimination — fix is correct by construction; CI over many runs is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)